### PR TITLE
Add admin/hero-shortlists.php — batch shortlist JSON endpoint (Stage 3U)

### DIFF
--- a/admin/hero-shortlists.php
+++ b/admin/hero-shortlists.php
@@ -1,0 +1,133 @@
+<?php
+require_once __DIR__ . '/db.php';
+require_once __DIR__ . '/../inc/hero/candidates.php';
+require_once __DIR__ . '/../inc/hero/diagnostics.php';
+require_once __DIR__ . '/../inc/hero/shortlist.php';
+
+header('Content-Type: application/json');
+
+$limit = (int)($_GET['limit'] ?? 25);
+$limit = max(1, min(100, $limit));
+$offset = (int)($_GET['offset'] ?? 0);
+$offset = max(0, $offset);
+$brand = trim((string)($_GET['brand'] ?? ''));
+$section = trim((string)($_GET['section'] ?? ''));
+$q = trim((string)($_GET['q'] ?? ''));
+
+$where = ["i.is_active = 1"];
+$params = [];
+
+if ($brand !== '') {
+    $where[] = 'LOWER(i.brand) = LOWER(:brand)';
+    $params[':brand'] = $brand;
+}
+
+if ($section !== '') {
+    // Conservative section matching because schema uses category hierarchy fields.
+    $where[] = '(LOWER(COALESCE(i.parentCategory, \"\")) = LOWER(:section_exact) OR LOWER(COALESCE(i.subcategory, \"\")) = LOWER(:section_exact) OR LOWER(COALESCE(i.categoryName, \"\")) = LOWER(:section_exact))';
+    $params[':section_exact'] = $section;
+}
+
+if ($q !== '') {
+    $where[] = '(i.itemName LIKE :q OR i.brand LIKE :q OR i.description LIKE :q OR i.categoryName LIKE :q)';
+    $params[':q'] = '%' . $q . '%';
+}
+
+$whereSql = 'WHERE ' . implode(' AND ', $where);
+
+$sql = "
+    SELECT
+        i.itemId,
+        i.itemName,
+        i.brand
+    FROM item i
+    {$whereSql}
+    ORDER BY i.brand ASC, i.itemName ASC, i.itemId ASC
+    LIMIT :limit OFFSET :offset
+";
+
+$stmt = $pdo->prepare($sql);
+foreach ($params as $name => $value) {
+    $stmt->bindValue($name, $value, PDO::PARAM_STR);
+}
+$stmt->bindValue(':limit', $limit, PDO::PARAM_INT);
+$stmt->bindValue(':offset', $offset, PDO::PARAM_INT);
+$stmt->execute();
+$items = $stmt->fetchAll(PDO::FETCH_ASSOC);
+
+$products = [];
+$readyCount = 0;
+$partialCount = 0;
+$unavailableCount = 0;
+$legacyPlaceholderCount = 0;
+
+foreach ($items as $item) {
+    $itemId = (int)($item['itemId'] ?? 0);
+    if ($itemId <= 0) {
+        continue;
+    }
+
+    $result = sw_enumerate_scored_candidates($pdo, $itemId);
+    $candidates = $result['candidates'] ?? [];
+
+    if (is_array($candidates)) {
+        foreach ($candidates as &$candidate) {
+            $candidate['diagnostics'] = sw_get_hero_diagnostic_for_image((string)($candidate['path'] ?? ''));
+        }
+        unset($candidate);
+    }
+
+    $shortlist = sw_build_hero_shortlist_contract($itemId, $candidates);
+
+    $productRecord = [
+        'item_id' => $itemId,
+        'item_name' => $item['itemName'] ?? null,
+        'brand' => $item['brand'] ?? null,
+        'active_criteria_profile' => $shortlist['active_criteria_profile'] ?? null,
+        'criteria_profile_metadata' => $shortlist['criteria_profile_metadata'] ?? [],
+        'shortlist_basis' => $shortlist['shortlist_basis'] ?? 'legacy_rank_placeholder',
+        'shortlist_status' => $shortlist['shortlist_status'] ?? 'unavailable',
+        'current_hero' => $shortlist['current_hero'] ?? null,
+        'recommended_candidates' => $shortlist['recommended_candidates'] ?? [],
+        'candidate_count' => is_array($candidates) ? count($candidates) : 0,
+        'challenge_endpoint' => 'admin/hero-candidates.php?item_id=' . $itemId . '&include_shortlist=1',
+    ];
+
+    if (($productRecord['shortlist_basis'] ?? '') === 'legacy_rank_placeholder') {
+        $legacyPlaceholderCount++;
+    }
+
+    switch ($productRecord['shortlist_status']) {
+        case 'ready':
+            $readyCount++;
+            break;
+        case 'partial':
+            $partialCount++;
+            break;
+        default:
+            $unavailableCount++;
+            break;
+    }
+
+    $products[] = $productRecord;
+}
+
+echo json_encode([
+    'status' => 'ready',
+    'shortlist_basis' => 'legacy_rank_placeholder',
+    'active_scope' => [
+        'section' => $section !== '' ? $section : null,
+        'brand' => $brand !== '' ? $brand : null,
+        'category' => null,
+        'limit' => $limit,
+        'offset' => $offset,
+    ],
+    'products' => $products,
+    'summary' => [
+        'product_count' => count($products),
+        'ready_count' => $readyCount,
+        'partial_count' => $partialCount,
+        'unavailable_count' => $unavailableCount,
+        'legacy_placeholder_count' => $legacyPlaceholderCount,
+    ],
+], JSON_UNESCAPED_SLASHES);


### PR DESCRIPTION
### Motivation
- Provide a read-only batch JSON endpoint to deliver compact top-three shortlist records for multiple products so the future Hero Manager product-list scan UI can display candidates efficiently.

### Description
- Added `admin/hero-shortlists.php`, a conservative, read-only JSON endpoint that supports `limit`, `offset`, `brand`, `section`, and `q` query parameters and enforces pagination defaults (default 25, max 100, offset >= 0).
- The endpoint only uses existing helpers (`sw_enumerate_scored_candidates()`, `sw_get_hero_diagnostic_for_image()`, and `sw_build_hero_shortlist_contract()`), returns the requested compact product records (no `all_candidates`), and includes `challenge_endpoint` linking to `admin/hero-candidates.php?item_id=...&include_shortlist=1`.
- `section` filtering is implemented conservatively by exact case-insensitive matching against existing catalog hierarchy fields (`parentCategory`, `subcategory`, `categoryName`), and `category` is returned as `null` in `active_scope` per current stage scope.
- This change is endpoint-only and does not modify UI, JS, CSS, scoring/ranking formulas, diagnostics adapters, schema, authority/override/rejection/import logic, or any preprocessing/generated artifacts.

### Testing
- Syntax check: `php -l admin/hero-shortlists.php` passed with no syntax errors.
- Smoke includes via CLI were attempted (`php -r 'parse_str("limit=5", $_GET); include "admin/hero-shortlists.php";'` and variants for `brand` and `q`) but runtime requests could not be fully validated here because the environment reported `Database connection failed.`.
- Automated checks confirmed the new file `admin/hero-shortlists.php` was created and that the endpoint code enumerates candidates, attaches diagnostics, builds shortlist contracts, and emits the expected top-level JSON shape (`status`, `shortlist_basis`, `active_scope`, `products`, `summary`).
- Supported filters: `limit`, `offset`, `brand`, `section`, `q`; skipped/limited filters: no dedicated `category` query parameter was added due to schema ambiguity and conservatively mapped `section` to existing fields instead.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a03cdb51ea88324a3861be9ad7945d4)