### PR TITLE
Stage 3X: add read-only shortlist preview to Hero Manager product list

### DIFF
--- a/admin/hero-manager.php
+++ b/admin/hero-manager.php
@@ -645,6 +645,10 @@ admin_layout_start("Hero Manager");
                     </div>
                 </div>
 
+                <div class="hero-shortlist-preview" data-shortlist-item-id="<?= $itemId ?>">
+                    <div class="hero-shortlist-preview__state">Loading shortlist…</div>
+                </div>
+
                 <!-- Buttons -->
                 <div class="hero-card__actions">
                     <a class="btn btn-primary" href="hero-edit.php?id=<?= $itemId ?>">
@@ -679,4 +683,3 @@ admin_layout_start("Hero Manager");
 <script src="<?= BASE_URL ?>/js/admin/hero.js"></script>
 
 <?php admin_layout_end();
-

--- a/css/admin/hero.css
+++ b/css/admin/hero.css
@@ -257,6 +257,60 @@
 }
 
 /* =========================================================
+   hero-manager — shortlist preview
+========================================================= */
+.hero-shortlist-preview {
+    margin-top: 8px;
+    padding: 8px;
+    border: 1px solid rgba(148,163,235,0.35);
+    border-radius: 10px;
+    background: rgba(2,6,23,0.45);
+    font-size: 0.75rem;
+}
+
+.hero-shortlist-preview__head,
+.hero-shortlist-preview__foot {
+    display: flex;
+    gap: 8px;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: space-between;
+}
+
+.hero-shortlist-preview__meta {
+    color: var(--text-muted);
+}
+
+.hero-shortlist-preview__thumbs {
+    display: flex;
+    gap: 8px;
+    margin: 8px 0;
+}
+
+.hero-shortlist-thumb { width: 72px; }
+.hero-shortlist-thumb__rank { display: inline-block; margin-bottom: 4px; }
+.hero-shortlist-thumb__imgwrap {
+    height: 84px;
+    border-radius: 8px;
+    overflow: hidden;
+    border: 1px solid rgba(148,163,235,0.4);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: #020617;
+}
+.hero-shortlist-thumb__imgwrap img {
+    max-width: 100%;
+    max-height: 100%;
+    object-fit: contain;
+}
+.hero-shortlist-preview__current { color: var(--text-muted); }
+.hero-shortlist-preview__flag {
+    margin-left: 8px;
+    color: #fecaca;
+}
+
+/* =========================================================
    HERO GOVERNANCE SEMANTICS
 ========================================================= */
 
@@ -341,7 +395,6 @@
 [data-fullscreen] {
     cursor: zoom-in;
 }
-
 
 
 

--- a/js/admin/hero.js
+++ b/js/admin/hero.js
@@ -162,5 +162,93 @@ document.addEventListener("DOMContentLoaded", () => {
     });
   });
 
-});
+  /* ------------------------------------------------------------
+     4. Shortlist Preview Panel (hero-manager.php, read-only)
+     ------------------------------------------------------------ */
 
+  const shortlistNodes = document.querySelectorAll("[data-shortlist-item-id]");
+  if (shortlistNodes.length > 0) {
+    const renderShortlistState = (node, message) => {
+      node.innerHTML = `<div class="hero-shortlist-preview__state">${message}</div>`;
+    };
+
+    fetch(`${window.BASE_URL}/admin/hero-shortlists.php?limit=100`)
+      .then(res => {
+        if (!res.ok) throw new Error("endpoint");
+        return res.json();
+      })
+      .then(data => {
+        const products = Array.isArray(data.products) ? data.products : [];
+        const byItem = new Map(products.map(p => [String(p.item_id), p]));
+
+        shortlistNodes.forEach(node => {
+          const itemId = String(node.dataset.shortlistItemId || "");
+          const product = byItem.get(itemId);
+
+          if (!product) {
+            renderShortlistState(node, "Shortlist unavailable");
+            return;
+          }
+
+          const candidates = Array.isArray(product.recommended_candidates)
+            ? product.recommended_candidates.slice(0, 3)
+            : [];
+
+          const currentHero = product.current_hero || null;
+          const outsideTopThree = !!(currentHero && currentHero.current_hero_outside_top_three);
+          const profile = product.active_criteria_profile || "—";
+          const basis = product.shortlist_basis || "legacy_rank_placeholder";
+          const challengeEndpoint = product.challenge_endpoint || `admin/hero-candidates.php?item_id=${encodeURIComponent(itemId)}&include_shortlist=1`;
+
+          if (candidates.length === 0) {
+            node.innerHTML = `
+              <div class="hero-shortlist-preview__head">
+                <strong>Shortlist preview</strong>
+                <span class="hero-shortlist-preview__meta">No candidates</span>
+              </div>
+              <div class="hero-shortlist-preview__foot">
+                <span>Profile: ${profile}</span>
+                <span>Basis: ${basis}</span>
+                <a href="${challengeEndpoint}">Review candidates</a>
+              </div>
+            `;
+            return;
+          }
+
+          const thumbs = candidates.map((candidate, idx) => {
+            const rank = candidate.recommendation_rank || (idx + 1);
+            const path = candidate.path || "";
+            return `
+              <div class="hero-shortlist-thumb">
+                <span class="hero-shortlist-thumb__rank">#${rank}</span>
+                <div class="hero-shortlist-thumb__imgwrap">
+                  ${path ? `<img src="${window.BASE_URL}/${path}" alt="Shortlist candidate #${rank}">` : "<span>—</span>"}
+                </div>
+              </div>
+            `;
+          }).join("");
+
+          node.innerHTML = `
+            <div class="hero-shortlist-preview__head">
+              <strong>Recommended shortlist</strong>
+              <span class="hero-shortlist-preview__meta">${product.shortlist_status || "unavailable"}</span>
+            </div>
+            <div class="hero-shortlist-preview__thumbs">${thumbs}</div>
+            <div class="hero-shortlist-preview__current">
+              Current hero: ${currentHero && currentHero.path ? "available" : "none"}
+              ${outsideTopThree ? '<span class="hero-shortlist-preview__flag">Current hero outside shortlist</span>' : ""}
+            </div>
+            <div class="hero-shortlist-preview__foot">
+              <span>Profile: ${profile}</span>
+              <span>Basis: ${basis}</span>
+              <a href="${challengeEndpoint}">Review candidates</a>
+            </div>
+          `;
+        });
+      })
+      .catch(() => {
+        shortlistNodes.forEach(node => renderShortlistState(node, "Endpoint error / unable to load shortlist"));
+      });
+  }
+
+});


### PR DESCRIPTION
### Motivation
- Implement the first read-only UI slice from Stage 3W to surface a compact top-three shortlist preview inside the existing Hero Manager product-list for quick scanning. 
- Provide a non-authoritative, clearly labelled shortlist preview and a path to full candidate review while preserving manual hero selection authority and avoiding claims about AI ranking.

### Description
- Added a per-item shortlist mount to the product card markup in `admin/hero-manager.php` (`data-shortlist-item-id`) that shows an initial `Loading shortlist…` state. 
- Implemented client-side loading and rendering in the existing module `js/admin/hero.js` to fetch `admin/hero-shortlists.php`, match items by `item_id`, render up to three `recommended_candidates` thumbnails with rank badges `#1/#2/#3`, show a compact current hero summary and flag `Current hero outside shortlist` when applicable, display `active_criteria_profile` and `shortlist_basis`, and link the provided `challenge_endpoint` as `Review candidates`. 
- Added scoped styles in `css/admin/hero.css` for the shortlist preview, thumbs, rank badges, metadata rows, and outside-shortlist flag. 
- No backend or endpoint contracts were modified, no `all_candidates` data is requested or rendered from the product-list mode, and no write actions or hero-selection persistence logic were changed.

### Testing
- Ran `git status --short` to confirm working tree changes and the modified files list succeeded. 
- Ran `php -l admin/hero-manager.php`, `php -l admin/hero-shortlists.php`, and `php -l admin/hero-candidates.php` and all three returned "No syntax errors detected". 
- Searched with `rg -n "all_candidates|hero-shortlists.php|recommended_candidates|Review candidates" admin/hero-manager.php js/admin/hero.js` to verify the product-list consumes only the batch shortlist fields and the `Review candidates` link is present, and the search results matched expectations.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a040a8871dc8324914ac15e0ec1269b)