### PR TITLE
Add shortlist preview to Hero Manager (UI, styles, client fetch)

### DIFF
--- a/admin/hero-manager.php
+++ b/admin/hero-manager.php
@@ -645,6 +645,10 @@ admin_layout_start("Hero Manager");
                     </div>
                 </div>
 
+                <div class="hero-shortlist-preview" data-shortlist-item-id="<?= $itemId ?>">
+                    <div class="hero-shortlist-preview__state">Loading shortlist…</div>
+                </div>
+
                 <!-- Buttons -->
                 <div class="hero-card__actions">
                     <a class="btn btn-primary" href="hero-edit.php?id=<?= $itemId ?>">
@@ -679,4 +683,3 @@ admin_layout_start("Hero Manager");
 <script src="<?= BASE_URL ?>/js/admin/hero.js"></script>
 
 <?php admin_layout_end();
-

--- a/css/admin/hero.css
+++ b/css/admin/hero.css
@@ -257,6 +257,60 @@
 }
 
 /* =========================================================
+   hero-manager — shortlist preview
+========================================================= */
+.hero-shortlist-preview {
+    margin-top: 8px;
+    padding: 8px;
+    border: 1px solid rgba(148,163,235,0.35);
+    border-radius: 10px;
+    background: rgba(2,6,23,0.45);
+    font-size: 0.75rem;
+}
+
+.hero-shortlist-preview__head,
+.hero-shortlist-preview__foot {
+    display: flex;
+    gap: 8px;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: space-between;
+}
+
+.hero-shortlist-preview__meta {
+    color: var(--text-muted);
+}
+
+.hero-shortlist-preview__thumbs {
+    display: flex;
+    gap: 8px;
+    margin: 8px 0;
+}
+
+.hero-shortlist-thumb { width: 72px; }
+.hero-shortlist-thumb__rank { display: inline-block; margin-bottom: 4px; }
+.hero-shortlist-thumb__imgwrap {
+    height: 84px;
+    border-radius: 8px;
+    overflow: hidden;
+    border: 1px solid rgba(148,163,235,0.4);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: #020617;
+}
+.hero-shortlist-thumb__imgwrap img {
+    max-width: 100%;
+    max-height: 100%;
+    object-fit: contain;
+}
+.hero-shortlist-preview__current { color: var(--text-muted); }
+.hero-shortlist-preview__flag {
+    margin-left: 8px;
+    color: #fecaca;
+}
+
+/* =========================================================
    HERO GOVERNANCE SEMANTICS
 ========================================================= */
 
@@ -341,7 +395,6 @@
 [data-fullscreen] {
     cursor: zoom-in;
 }
-
 
 
 

--- a/js/admin/hero.js
+++ b/js/admin/hero.js
@@ -162,5 +162,122 @@ document.addEventListener("DOMContentLoaded", () => {
     });
   });
 
-});
+  /* ------------------------------------------------------------
+     4. Shortlist Preview Panel (hero-manager.php, read-only)
+     ------------------------------------------------------------ */
 
+  const shortlistNodes = document.querySelectorAll("[data-shortlist-item-id]");
+  if (shortlistNodes.length > 0) {
+    const clearNode = node => { while (node.firstChild) node.removeChild(node.firstChild); };
+    const safeText = value => (value === null || value === undefined || value === "") ? "—" : String(value);
+    const isAbsoluteUrl = url => /^https?:\/\//i.test(url) || url.startsWith("/");
+    const resolveImageUrl = path => {
+      const cleanPath = String(path || "").replace(/^\/+/, "");
+      return `${window.BASE_URL}/${cleanPath}`;
+    };
+    const resolveChallengeUrl = (endpoint, itemId) => {
+      const fallback = `/admin/hero-candidates.php?item_id=${encodeURIComponent(itemId)}&include_shortlist=1`;
+      const raw = String(endpoint || fallback).trim();
+      if (raw === "") return `${window.BASE_URL}${fallback}`;
+      if (isAbsoluteUrl(raw)) return raw;
+      const normalized = raw.replace(/^\/+/, "");
+      if (normalized.startsWith("admin/")) return `${window.BASE_URL}/${normalized.slice("admin/".length)}`;
+      return `${window.BASE_URL}/${normalized}`;
+    };
+    const makeEl = (tag, className, text) => {
+      const el = document.createElement(tag);
+      if (className) el.className = className;
+      if (text !== undefined) el.textContent = text;
+      return el;
+    };
+    const renderShortlistState = (node, message) => {
+      clearNode(node);
+      node.appendChild(makeEl("div", "hero-shortlist-preview__state", message));
+    };
+
+    fetch(`${window.BASE_URL}/admin/hero-shortlists.php?limit=100`)
+      .then(res => {
+        if (!res.ok) throw new Error("endpoint");
+        return res.json();
+      })
+      .then(data => {
+        const products = Array.isArray(data.products) ? data.products : [];
+        const byItem = new Map(products.map(p => [String(p.item_id), p]));
+
+        shortlistNodes.forEach(node => {
+          const itemId = String(node.dataset.shortlistItemId || "");
+          const product = byItem.get(itemId);
+
+          if (!product) {
+            renderShortlistState(node, "Shortlist unavailable");
+            return;
+          }
+
+          const candidates = Array.isArray(product.recommended_candidates)
+            ? product.recommended_candidates.slice(0, 3)
+            : [];
+
+          const currentHero = product.current_hero || null;
+          const outsideTopThree = !!(currentHero && currentHero.current_hero_outside_top_three);
+          const profile = product.active_criteria_profile || "—";
+          const basis = product.shortlist_basis || "legacy_rank_placeholder";
+          const challengeEndpoint = resolveChallengeUrl(product.challenge_endpoint, itemId);
+
+          clearNode(node);
+          const head = makeEl("div", "hero-shortlist-preview__head");
+          head.appendChild(makeEl("strong", "", candidates.length === 0 ? "Shortlist preview" : "Recommended shortlist"));
+          head.appendChild(makeEl("span", "hero-shortlist-preview__meta", candidates.length === 0 ? "No candidates" : safeText(product.shortlist_status || "unavailable")));
+          node.appendChild(head);
+
+          if (candidates.length === 0) {
+            const foot = makeEl("div", "hero-shortlist-preview__foot");
+            foot.appendChild(makeEl("span", "", `Profile: ${safeText(profile)}`));
+            foot.appendChild(makeEl("span", "", `Basis: ${safeText(basis)}`));
+            const review = makeEl("a", "", "Review candidates");
+            review.href = challengeEndpoint;
+            foot.appendChild(review);
+            node.appendChild(foot);
+            return;
+          }
+
+          const thumbsWrap = makeEl("div", "hero-shortlist-preview__thumbs");
+          candidates.forEach((candidate, idx) => {
+            const rank = candidate.recommendation_rank || (idx + 1);
+            const path = candidate.path || "";
+            const thumb = makeEl("div", "hero-shortlist-thumb");
+            thumb.appendChild(makeEl("span", "hero-shortlist-thumb__rank", `#${rank}`));
+            const imgWrap = makeEl("div", "hero-shortlist-thumb__imgwrap");
+            if (path) {
+              const img = document.createElement("img");
+              img.src = resolveImageUrl(path);
+              img.alt = `Shortlist candidate #${rank}`;
+              imgWrap.appendChild(img);
+            } else {
+              imgWrap.appendChild(makeEl("span", "", "—"));
+            }
+            thumb.appendChild(imgWrap);
+            thumbsWrap.appendChild(thumb);
+          });
+          node.appendChild(thumbsWrap);
+
+          const current = makeEl("div", "hero-shortlist-preview__current", `Current hero: ${currentHero && currentHero.path ? "available" : "none"}`);
+          if (outsideTopThree) {
+            current.appendChild(makeEl("span", "hero-shortlist-preview__flag", "Current hero outside shortlist"));
+          }
+          node.appendChild(current);
+
+          const foot = makeEl("div", "hero-shortlist-preview__foot");
+          foot.appendChild(makeEl("span", "", `Profile: ${safeText(profile)}`));
+          foot.appendChild(makeEl("span", "", `Basis: ${safeText(basis)}`));
+          const review = makeEl("a", "", "Review candidates");
+          review.href = challengeEndpoint;
+          foot.appendChild(review);
+          node.appendChild(foot);
+        });
+      })
+      .catch(() => {
+        shortlistNodes.forEach(node => renderShortlistState(node, "Endpoint error / unable to load shortlist"));
+      });
+  }
+
+});


### PR DESCRIPTION
### Motivation
- Surface the recommended shortlist for each product on the hero manager page so reviewers can quickly see the top candidates without leaving the list view.
- Provide a compact, read-only preview that links to the full candidate review workflow and signals when the selected hero is outside the shortlist.

### Description
- Inserted a read-only preview container in `admin/hero-manager.php` with `data-shortlist-item-id` to host the shortlist UI for each product.
- Added styles in `css/admin/hero.css` for `.hero-shortlist-preview`, thumbnail layout, ranking badges, and state/flag visuals.
- Implemented client-side logic in `js/admin/hero.js` to fetch `/admin/hero-shortlists.php?limit=100`, map responses by `item_id`, and render up to three recommended candidates per product, including current-hero state, profile/basis metadata, and a link to review candidates; includes helpers for URL resolution and error handling.

### Testing
- No new unit tests were added; syntax and basic linters were run against the changed files: `php -l` on PHP files and `eslint` on the modified JS file, and both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a040a8871dc8324914ac15e0ec1269b)