### PR TITLE
Stage 3AD: add hero override rationale storage migration

### DIFF
--- a/db/migrations/2026-05-14-stage-3ad-hero-override-rationale.sql
+++ b/db/migrations/2026-05-14-stage-3ad-hero-override-rationale.sql
@@ -1,0 +1,44 @@
+-- Stage 3AD: Human Override Rationale storage migration
+-- Purpose: add a history-capable table to store administrator rationale
+-- when selecting/confirming hero images that differ from recommendations.
+
+CREATE TABLE IF NOT EXISTS hero_override_rationale (
+    rationale_id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+    itemId INT NOT NULL,
+
+    -- Snapshot of hero decision context at save time
+    selected_hero_image VARCHAR(1024) NOT NULL,
+    current_hero_image VARCHAR(1024) DEFAULT NULL,
+    active_criteria_profile VARCHAR(128) DEFAULT NULL,
+    shortlist_basis VARCHAR(128) DEFAULT NULL,
+    current_hero_rank TINYINT UNSIGNED DEFAULT NULL,
+    current_hero_outside_top_three TINYINT(1) NOT NULL DEFAULT 0,
+
+    -- Structured rationale payload
+    selected_reason_codes JSON NOT NULL,
+    optional_note TEXT DEFAULT NULL,
+
+    -- Signals for future criteria/image quality improvements
+    criteria_refinement_signal TINYINT(1) NOT NULL DEFAULT 0,
+    image_set_limitation_signal TINYINT(1) NOT NULL DEFAULT 0,
+    metadata_issue_signal TINYINT(1) NOT NULL DEFAULT 0,
+    diagnostics_issue_signal TINYINT(1) NOT NULL DEFAULT 0,
+
+    -- Active/supersession tracking for history-capable storage
+    is_active TINYINT(1) NOT NULL DEFAULT 1,
+    superseded_at DATETIME DEFAULT NULL,
+
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+
+    PRIMARY KEY (rationale_id),
+    KEY idx_hor_item (itemId),
+    KEY idx_hor_is_active (is_active),
+    KEY idx_hor_item_active (itemId, is_active),
+    KEY idx_hor_active_criteria_profile (active_criteria_profile),
+    KEY idx_hor_created_at (created_at),
+    KEY idx_hor_criteria_refinement_signal (criteria_refinement_signal),
+    KEY idx_hor_image_set_limitation_signal (image_set_limitation_signal),
+    KEY idx_hor_metadata_issue_signal (metadata_issue_signal),
+    KEY idx_hor_diagnostics_issue_signal (diagnostics_issue_signal)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;


### PR DESCRIPTION
### Motivation
- Provide a dedicated, history-capable storage foundation for administrator "human override" rationale so manual hero selections can be recorded without weakening manual authority.
- Preserve the decision-time context and structured signals required for future reporting and criteria-refinement work. 

### Description
- Add one new SQL migration `db/migrations/2026-05-14-stage-3ad-hero-override-rationale.sql` which creates the `hero_override_rationale` table using `CREATE TABLE IF NOT EXISTS` (InnoDB, `utf8mb4`).
- The table captures snapshot context (`selected_hero_image`, `current_hero_image`, `active_criteria_profile`, `shortlist_basis`, `current_hero_rank`, `current_hero_outside_top_three`), a JSON-first `selected_reason_codes` payload and `optional_note`, boolean review/refinement signals, history lifecycle fields (`is_active`, `superseded_at`), and timestamps (`created_at`, `updated_at`).
- Add targeted indexes for `itemId`, `is_active`, `active_criteria_profile`, `created_at`, and each signal field to support efficient reporting and lookups. 

### Testing
- Repository inspection commands (`rg` searches and `sed` previews) were run to confirm existing SQL/migration locations and conventions and they succeeded.
- The migration file was inspected with `nl -ba db/migrations/2026-05-14-stage-3ad-hero-override-rationale.sql` to verify schema and indexes and the output matched the intended design.
- `git diff --check` was run and reported no whitespace or diff-check issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05cff381b48324ad87a3a200958c69)