### PR TITLE
Stage 3AF: Add collapsed per-card human override rationale UI in Hero Manager

### DIFF
--- a/admin/hero-manager.php
+++ b/admin/hero-manager.php
@@ -625,6 +625,21 @@ admin_layout_start("Hero Manager");
                     <div class="hero-shortlist-preview" data-shortlist-item-id="<?= $itemId ?>">
                         <div class="hero-shortlist-preview__state">Loading shortlist…</div>
                     </div>
+                    <div
+                        class="hero-rationale"
+                        data-rationale-item-id="<?= $itemId ?>"
+                        data-current-hero-image="<?= htmlspecialchars($currentHeroImage ?? '') ?>"
+                    >
+                        <div class="hero-rationale__status-row">
+                            <span class="hero-rationale__status-badge is-neutral" data-rationale-status>No rationale saved</span>
+                            <button type="button" class="hero-rationale__toggle" data-rationale-toggle>
+                                Record rationale
+                            </button>
+                        </div>
+                        <div class="hero-rationale__panel" data-rationale-panel hidden>
+                            <div class="hero-rationale__panel-state" data-rationale-feedback>Loading rationale…</div>
+                        </div>
+                    </div>
 
                     <!-- Candidates -->
                     <div

--- a/css/admin/hero.css
+++ b/css/admin/hero.css
@@ -320,6 +320,85 @@
     }
 }
 
+.hero-rationale {
+    margin-top: 8px;
+    border: 1px solid rgba(148,163,235,0.25);
+    border-radius: 12px;
+    background: rgba(2,6,23,0.45);
+    padding: 8px;
+}
+
+.hero-rationale__status-row {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 8px;
+    flex-wrap: wrap;
+}
+
+.hero-rationale__status-badge {
+    font-size: 0.72rem;
+    border-radius: 999px;
+    padding: 3px 8px;
+    border: 1px solid rgba(148,163,235,0.4);
+}
+
+.hero-rationale__status-badge.is-neutral { color: #cbd5e1; }
+.hero-rationale__status-badge.is-needed { color: #fda4af; border-color: rgba(251,113,133,0.75); }
+.hero-rationale__status-badge.is-saved { color: #86efac; border-color: rgba(74,222,128,0.7); }
+
+.hero-rationale__toggle {
+    border: 1px solid rgba(192,132,252,0.6);
+    background: rgba(88,28,135,0.35);
+    color: #f5d0fe;
+    border-radius: 999px;
+    padding: 4px 10px;
+    font-size: 0.72rem;
+}
+
+.hero-rationale__panel {
+    margin-top: 8px;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.hero-rationale__panel-state {
+    font-size: 0.72rem;
+    color: #cbd5e1;
+}
+
+.hero-rationale__group,
+.hero-rationale__signals {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 6px 10px;
+}
+
+.hero-rationale__check {
+    display: flex;
+    gap: 6px;
+    align-items: flex-start;
+    font-size: 0.75rem;
+    color: #e2e8f0;
+}
+
+.hero-rationale__field span {
+    display: block;
+    font-size: 0.72rem;
+    margin-bottom: 4px;
+    color: var(--text-muted);
+}
+
+.hero-rationale__field textarea {
+    width: 100%;
+    background: rgba(15,23,42,0.8);
+    border: 1px solid rgba(148,163,235,0.3);
+    border-radius: 10px;
+    color: #e2e8f0;
+    padding: 8px;
+}
+
 /* =========================================================
    hero-manager — shortlist preview
 ========================================================= */
@@ -592,5 +671,4 @@
 [data-fullscreen] {
     cursor: zoom-in;
 }
-
 

--- a/js/admin/hero.js
+++ b/js/admin/hero.js
@@ -7,6 +7,8 @@
    ============================================================ */
 
 document.addEventListener("DOMContentLoaded", () => {
+  const baseUrl = String(window.BASE_URL || "").replace(/\/+$/, "");
+  const shortlistByItem = new Map();
 
   /* ------------------------------------------------------------
      1. PhotoSwipe Fullscreen Viewer
@@ -180,14 +182,12 @@ document.addEventListener("DOMContentLoaded", () => {
     };
 
     const resolveImageUrl = path => {
-      const baseUrl = String(window.BASE_URL || "").replace(/\/+$/, "");
       const cleanPath = String(path || "").replace(/^\/+/, "");
 
       return `${baseUrl}/${cleanPath}`;
     };
 
     const resolveChallengeUrl = (endpoint, itemId) => {
-      const baseUrl = String(window.BASE_URL || "").replace(/\/+$/, "");
       const fallback = `admin/hero-candidates.php?item_id=${encodeURIComponent(itemId)}&include_shortlist=1`;
       const raw = String(endpoint || fallback).trim();
 
@@ -250,6 +250,7 @@ document.addEventListener("DOMContentLoaded", () => {
         shortlistNodes.forEach(node => {
           const itemId = String(node.dataset.shortlistItemId || "");
           const product = byItem.get(itemId);
+          shortlistByItem.set(itemId, product || null);
 
           if (!product) {
             renderShortlistState(node, "Shortlist unavailable");
@@ -345,9 +346,205 @@ document.addEventListener("DOMContentLoaded", () => {
       })
       .catch(() => {
         shortlistNodes.forEach(node => {
+          shortlistByItem.set(String(node.dataset.shortlistItemId || ""), null);
           renderShortlistState(node, "Endpoint error / unable to load shortlist");
         });
       });
   }
+
+  const reasonOptions = [
+    ["rear_facing_unsuitable_angle", "Rear-facing / unsuitable angle"],
+    ["side_facing_insufficiently_clear", "Side-facing / insufficiently clear"],
+    ["product_visible_but_not_primary_hero_suitable", "Visible but not primary-hero suitable"],
+    ["product_focus_conflicts_with_editorial_presentation", "Focus conflicts with editorial presentation"],
+    ["full_body_model_presentation_preferred", "Full-body model presentation preferred"],
+    ["face_or_model_context_needed", "Face or model context needed"],
+    ["criteria_profile_probably_wrong", "Criteria profile probably wrong"],
+    ["product_or_category_metadata_may_be_wrong", "Product/category metadata may be wrong"],
+    ["diagnostics_or_ranking_appear_wrong", "Diagnostics/ranking appear wrong"],
+    ["no_ideal_image_exists", "No ideal image exists"],
+    ["human_editorial_judgement_override", "Human editorial judgement override"]
+  ];
+
+  const signalOptions = [
+    ["criteria_refinement_signal", "Criteria review signal"],
+    ["image_set_limitation_signal", "Image-set limitation"],
+    ["metadata_issue_signal", "Metadata/category issue"],
+    ["diagnostics_issue_signal", "Diagnostics/ranking issue"]
+  ];
+
+  const rationaleNodes = document.querySelectorAll("[data-rationale-item-id]");
+  const closeAllRationalePanels = current => {
+    rationaleNodes.forEach(node => {
+      if (node !== current) {
+        const panel = node.querySelector("[data-rationale-panel]");
+        if (panel) panel.hidden = true;
+      }
+    });
+  };
+
+  const statusClasses = ["is-neutral", "is-needed", "is-saved"];
+  const setStatus = (node, text, className) => {
+    const badge = node.querySelector("[data-rationale-status]");
+    if (!badge) return;
+    badge.textContent = text;
+    badge.classList.remove(...statusClasses);
+    badge.classList.add(className || "is-neutral");
+  };
+
+  const createForm = node => {
+    const panel = node.querySelector("[data-rationale-panel]");
+    if (!panel || panel.dataset.formBuilt) return panel;
+
+    panel.innerHTML = `
+      <div class="hero-rationale__panel-state" data-rationale-feedback></div>
+      <div class="hero-rationale__group" data-reason-group></div>
+      <label class="hero-rationale__field">
+        <span>Optional note</span>
+        <textarea data-rationale-note rows="3" placeholder="Explain why the selected/current hero is preferred despite the shortlist result."></textarea>
+      </label>
+      <div class="hero-rationale__signals" data-signal-group></div>
+      <div class="hero-rationale__actions">
+        <button type="button" class="btn btn-primary btn-sm" data-rationale-save>Save rationale</button>
+      </div>
+    `;
+
+    const reasonWrap = panel.querySelector("[data-reason-group]");
+    reasonOptions.forEach(([code, label]) => {
+      const row = document.createElement("label");
+      row.className = "hero-rationale__check";
+      row.innerHTML = `<input type="checkbox" data-reason-code="${code}"> <span>${label}</span>`;
+      reasonWrap.appendChild(row);
+    });
+
+    const signalWrap = panel.querySelector("[data-signal-group]");
+    signalOptions.forEach(([code, label]) => {
+      const row = document.createElement("label");
+      row.className = "hero-rationale__check hero-rationale__check--signal";
+      row.innerHTML = `<input type="checkbox" data-signal-code="${code}"> <span>${label}</span>`;
+      signalWrap.appendChild(row);
+    });
+
+    panel.dataset.formBuilt = "1";
+    return panel;
+  };
+
+  const hydrateForm = (node, rationale) => {
+    const panel = createForm(node);
+    if (!panel) return;
+    const reasonCodes = new Set(Array.isArray(rationale?.selected_reason_codes) ? rationale.selected_reason_codes : []);
+    panel.querySelectorAll("[data-reason-code]").forEach(input => {
+      input.checked = reasonCodes.has(input.dataset.reasonCode);
+    });
+    panel.querySelector("[data-rationale-note]").value = rationale?.optional_note || "";
+    panel.querySelectorAll("[data-signal-code]").forEach(input => {
+      input.checked = !!rationale?.[input.dataset.signalCode];
+    });
+  };
+
+  const fetchRationale = async node => {
+    const itemId = node.dataset.rationaleItemId;
+    const panel = createForm(node);
+    const feedback = panel.querySelector("[data-rationale-feedback]");
+    feedback.textContent = "Loading rationale…";
+
+    const res = await fetch(`${baseUrl}/admin/hero-rationale.php?item_id=${encodeURIComponent(itemId)}`);
+    const data = await res.json();
+    if (!res.ok || !data.ok) throw new Error(data.error || "Failed to read rationale");
+
+    node._rationale = data.rationale || null;
+    hydrateForm(node, node._rationale);
+    feedback.textContent = node._rationale ? "Loaded saved rationale." : "No saved rationale yet.";
+    const toggle = node.querySelector("[data-rationale-toggle]");
+    if (toggle) toggle.textContent = node._rationale ? "View / edit rationale" : "Record rationale";
+  };
+
+  const applyStatusFromState = node => {
+    const itemId = String(node.dataset.rationaleItemId || "");
+    const shortlist = shortlistByItem.get(itemId);
+    const saved = !!node._rationale;
+    const outside = !!(shortlist && shortlist.current_hero && shortlist.current_hero.current_hero_outside_top_three);
+
+    if (saved) {
+      setStatus(node, "Rationale saved", "is-saved");
+      return;
+    }
+    if (outside) {
+      setStatus(node, "Rationale needed · Current hero outside shortlist", "is-needed");
+      return;
+    }
+    setStatus(node, "No rationale saved", "is-neutral");
+  };
+
+  const saveRationale = async node => {
+    const itemId = Number(node.dataset.rationaleItemId || 0);
+    const panel = createForm(node);
+    const feedback = panel.querySelector("[data-rationale-feedback]");
+    const shortlist = shortlistByItem.get(String(itemId)) || null;
+
+    const selectedReasonCodes = Array.from(panel.querySelectorAll("[data-reason-code]:checked")).map(input => input.dataset.reasonCode);
+    const signals = {};
+    panel.querySelectorAll("[data-signal-code]").forEach(input => {
+      signals[input.dataset.signalCode] = input.checked;
+    });
+
+    const currentHero = shortlist?.current_hero || {};
+    const payload = {
+      itemId,
+      selected_hero_image: String(node.dataset.currentHeroImage || currentHero.path || "").trim(),
+      current_hero_image: String(node.dataset.currentHeroImage || currentHero.path || "").trim(),
+      active_criteria_profile: shortlist?.active_criteria_profile || null,
+      shortlist_basis: shortlist?.shortlist_basis || null,
+      current_hero_rank: currentHero.current_hero_rank ?? null,
+      current_hero_outside_top_three: !!currentHero.current_hero_outside_top_three,
+      selected_reason_codes: selectedReasonCodes,
+      optional_note: panel.querySelector("[data-rationale-note]").value.trim(),
+      ...signals
+    };
+
+    feedback.textContent = "Saving rationale…";
+    const res = await fetch(`${baseUrl}/admin/hero-rationale.php`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload)
+    });
+    const data = await res.json();
+    if (!res.ok || !data.ok) throw new Error(data.error || "Failed to save rationale");
+    await fetchRationale(node);
+    applyStatusFromState(node);
+    feedback.textContent = "Rationale saved.";
+  };
+
+  rationaleNodes.forEach(node => {
+    createForm(node);
+    fetchRationale(node).catch(err => {
+      const panel = node.querySelector("[data-rationale-panel]");
+      const feedback = panel ? panel.querySelector("[data-rationale-feedback]") : null;
+      if (feedback) feedback.textContent = err.message || "Unable to load rationale.";
+    }).finally(() => {
+      applyStatusFromState(node);
+    });
+
+    const toggle = node.querySelector("[data-rationale-toggle]");
+    if (toggle) {
+      toggle.addEventListener("click", () => {
+        const panel = node.querySelector("[data-rationale-panel]");
+        if (!panel) return;
+        const willOpen = panel.hidden;
+        closeAllRationalePanels(node);
+        panel.hidden = !willOpen;
+      });
+    }
+
+    node.addEventListener("click", event => {
+      const saveBtn = event.target.closest("[data-rationale-save]");
+      if (!saveBtn) return;
+      saveRationale(node).catch(err => {
+        const panel = node.querySelector("[data-rationale-panel]");
+        const feedback = panel ? panel.querySelector("[data-rationale-feedback]") : null;
+        if (feedback) feedback.textContent = err.message || "Unable to save rationale.";
+      });
+    });
+  });
 
 });


### PR DESCRIPTION
### Motivation
- Provide administrators a collapsed, per-product UI in the Hero Manager to record and view human override rationale tied to the existing server endpoint without changing hero selection logic.
- Surface whether rationale is needed or saved and allow structured reason selection, optional notes, and small diagnostic signals so editorial decisions are auditable.
- Keep the new UI scoped and non-invasive: it must not alter `hero_image`, `hero_override`, shortlist/candidate behavior, scoring, or database schema.

### Description
- Added a per-item collapsed rationale block inside the existing insights area in `admin/hero-manager.php` that shows a status badge and a toggle to open an editable panel.
- Implemented frontend logic in `js/admin/hero.js` that loads shortlist context, fetches existing rationale via `GET admin/hero-rationale.php?item_id=...`, renders Stage 3AE reason-code checkboxes and signal checkboxes, provides an optional note textarea, and posts saves to `POST admin/hero-rationale.php` with the specified payload fields using safe null/default values when shortlist context is unavailable.
- Ensured UX behaviours: panel is collapsed by default, opens only for the selected product, shows loading/feedback messages, updates status (`Rationale saved`, `Rationale needed · Current hero outside shortlist`, `No rationale saved`), and keeps only one panel open at a time.
- Added scoped styles to `css/admin/hero.css` to match existing Hero Manager visual language (dark panel, compact badges, rounded controls) and kept backend read/save contract unchanged by reusing `admin/hero-rationale.php` and `inc/hero/rationale.php` validation.

### Testing
- Ran `php -l admin/hero-manager.php` and it returned no syntax errors.
- Ran `node --check js/admin/hero.js` and it returned no syntax errors.
- Ran `git diff --check` (no issues) and verified the expected files were modified: `admin/hero-manager.php`, `js/admin/hero.js`, `css/admin/hero.css`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a065b82f980832495c5cc36bc2bf811)