### PR TITLE
Improve rationale save UX and guard against duplicate unchanged saves

### DIFF
--- a/admin/hero-rationale.php
+++ b/admin/hero-rationale.php
@@ -48,13 +48,14 @@ if ($method === 'POST') {
 
     try {
         $itemId = (int)($payload['itemId'] ?? 0);
-        $rationaleId = sw_hero_rationale_save($pdo, $payload);
+        $saveResult = sw_hero_rationale_save($pdo, $payload);
 
         echo json_encode([
             'ok' => true,
             'item_id' => $itemId,
-            'rationale_id' => $rationaleId,
-            'message' => 'Rationale saved',
+            'rationale_id' => (int)$saveResult['rationale_id'],
+            'message' => !empty($saveResult['unchanged']) ? 'No changes to save' : 'Rationale saved',
+            'unchanged' => !empty($saveResult['unchanged']),
         ], JSON_UNESCAPED_SLASHES);
         exit;
     } catch (InvalidArgumentException $e) {

--- a/css/admin/hero.css
+++ b/css/admin/hero.css
@@ -672,3 +672,15 @@
     cursor: zoom-in;
 }
 
+
+.hero-rationale__actions [data-rationale-save].is-saving,
+.hero-rationale__actions [data-rationale-save]:disabled {
+    opacity: 0.8;
+    cursor: not-allowed;
+}
+
+.hero-rationale__actions [data-rationale-save].is-saved {
+    border-color: rgba(74,222,128,0.7);
+    background: rgba(22,101,52,0.28);
+    color: #bbf7d0;
+}

--- a/inc/hero/rationale.php
+++ b/inc/hero/rationale.php
@@ -97,7 +97,41 @@ function sw_hero_rationale_validate_reason_codes(array $reasonCodes): array
     ];
 }
 
-function sw_hero_rationale_save(PDO $pdo, array $payload): int
+function sw_hero_rationale_normalize_for_compare(array $row): array
+{
+    $reasonCodes = $row['selected_reason_codes'] ?? [];
+    if (!is_array($reasonCodes)) {
+        $parsed = sw_hero_rationale_parse_reason_codes((string)$reasonCodes);
+        $reasonCodes = $parsed['codes'];
+    }
+
+    $normalizedCodes = [];
+    foreach ($reasonCodes as $code) {
+        if (is_string($code) && trim($code) !== '') {
+            $normalizedCodes[] = trim($code);
+        }
+    }
+    $normalizedCodes = array_values(array_unique($normalizedCodes));
+    sort($normalizedCodes);
+
+    return [
+        'itemId' => (int)($row['itemId'] ?? 0),
+        'selected_hero_image' => trim((string)($row['selected_hero_image'] ?? '')),
+        'current_hero_image' => trim((string)($row['current_hero_image'] ?? '')),
+        'active_criteria_profile' => trim((string)($row['active_criteria_profile'] ?? '')),
+        'shortlist_basis' => trim((string)($row['shortlist_basis'] ?? '')),
+        'current_hero_rank' => isset($row['current_hero_rank']) && $row['current_hero_rank'] !== '' ? (int)$row['current_hero_rank'] : null,
+        'current_hero_outside_top_three' => !empty($row['current_hero_outside_top_three']),
+        'selected_reason_codes' => $normalizedCodes,
+        'optional_note' => trim((string)($row['optional_note'] ?? '')),
+        'criteria_refinement_signal' => !empty($row['criteria_refinement_signal']),
+        'image_set_limitation_signal' => !empty($row['image_set_limitation_signal']),
+        'metadata_issue_signal' => !empty($row['metadata_issue_signal']),
+        'diagnostics_issue_signal' => !empty($row['diagnostics_issue_signal']),
+    ];
+}
+
+function sw_hero_rationale_save(PDO $pdo, array $payload): array
 {
     $itemId = (int)($payload['itemId'] ?? 0);
     if ($itemId <= 0) {
@@ -117,6 +151,33 @@ function sw_hero_rationale_save(PDO $pdo, array $payload): int
     $validation = sw_hero_rationale_validate_reason_codes($reasonCodes);
     if (!empty($validation['invalid'])) {
         throw new InvalidArgumentException('Unknown reason codes: ' . implode(', ', array_map('strval', $validation['invalid'])));
+    }
+
+    $normalizedPayload = sw_hero_rationale_normalize_for_compare([
+        'itemId' => $itemId,
+        'selected_hero_image' => $selectedHeroImage,
+        'current_hero_image' => $payload['current_hero_image'] ?? '',
+        'active_criteria_profile' => $payload['active_criteria_profile'] ?? '',
+        'shortlist_basis' => $payload['shortlist_basis'] ?? '',
+        'current_hero_rank' => $payload['current_hero_rank'] ?? null,
+        'current_hero_outside_top_three' => $payload['current_hero_outside_top_three'] ?? false,
+        'selected_reason_codes' => $validation['codes'],
+        'optional_note' => $payload['optional_note'] ?? '',
+        'criteria_refinement_signal' => $payload['criteria_refinement_signal'] ?? false,
+        'image_set_limitation_signal' => $payload['image_set_limitation_signal'] ?? false,
+        'metadata_issue_signal' => $payload['metadata_issue_signal'] ?? false,
+        'diagnostics_issue_signal' => $payload['diagnostics_issue_signal'] ?? false,
+    ]);
+
+    $active = sw_hero_rationale_fetch_active($pdo, $itemId);
+    if ($active) {
+        $normalizedActive = sw_hero_rationale_normalize_for_compare($active);
+        if ($normalizedActive === $normalizedPayload) {
+            return [
+                'rationale_id' => (int)$active['rationale_id'],
+                'unchanged' => true,
+            ];
+        }
     }
 
     $encodedReasonCodes = json_encode($validation['codes'], JSON_UNESCAPED_SLASHES);
@@ -149,24 +210,27 @@ function sw_hero_rationale_save(PDO $pdo, array $payload): int
         $insert->execute([
             ':item_id' => $itemId,
             ':selected_hero_image' => $selectedHeroImage,
-            ':current_hero_image' => trim((string)($payload['current_hero_image'] ?? '')),
-            ':active_criteria_profile' => trim((string)($payload['active_criteria_profile'] ?? '')),
-            ':shortlist_basis' => trim((string)($payload['shortlist_basis'] ?? '')),
-            ':current_hero_rank' => isset($payload['current_hero_rank']) && $payload['current_hero_rank'] !== '' ? (int)$payload['current_hero_rank'] : null,
-            ':current_hero_outside_top_three' => !empty($payload['current_hero_outside_top_three']) ? 1 : 0,
+            ':current_hero_image' => $normalizedPayload['current_hero_image'],
+            ':active_criteria_profile' => $normalizedPayload['active_criteria_profile'],
+            ':shortlist_basis' => $normalizedPayload['shortlist_basis'],
+            ':current_hero_rank' => $normalizedPayload['current_hero_rank'],
+            ':current_hero_outside_top_three' => $normalizedPayload['current_hero_outside_top_three'] ? 1 : 0,
             ':selected_reason_codes' => $encodedReasonCodes,
-            ':optional_note' => trim((string)($payload['optional_note'] ?? '')),
-            ':criteria_refinement_signal' => !empty($payload['criteria_refinement_signal']) ? 1 : 0,
-            ':image_set_limitation_signal' => !empty($payload['image_set_limitation_signal']) ? 1 : 0,
-            ':metadata_issue_signal' => !empty($payload['metadata_issue_signal']) ? 1 : 0,
-            ':diagnostics_issue_signal' => !empty($payload['diagnostics_issue_signal']) ? 1 : 0,
+            ':optional_note' => $normalizedPayload['optional_note'],
+            ':criteria_refinement_signal' => $normalizedPayload['criteria_refinement_signal'] ? 1 : 0,
+            ':image_set_limitation_signal' => $normalizedPayload['image_set_limitation_signal'] ? 1 : 0,
+            ':metadata_issue_signal' => $normalizedPayload['metadata_issue_signal'] ? 1 : 0,
+            ':diagnostics_issue_signal' => $normalizedPayload['diagnostics_issue_signal'] ? 1 : 0,
             ':created_at' => $now,
             ':updated_at' => $now,
         ]);
 
         $rationaleId = (int)$pdo->lastInsertId();
         $pdo->commit();
-        return $rationaleId;
+        return [
+            'rationale_id' => $rationaleId,
+            'unchanged' => false,
+        ];
     } catch (Throwable $e) {
         if ($pdo->inTransaction()) {
             $pdo->rollBack();

--- a/js/admin/hero.js
+++ b/js/admin/hero.js
@@ -429,6 +429,53 @@ document.addEventListener("DOMContentLoaded", () => {
     return panel;
   };
 
+  const canonicalizeRationaleState = state => {
+    const reasonCodes = Array.isArray(state?.selected_reason_codes) ? state.selected_reason_codes : [];
+    const normalizedCodes = Array.from(new Set(reasonCodes.map(code => String(code || "").trim()).filter(Boolean))).sort();
+
+    return {
+      itemId: Number(state?.itemId || 0),
+      selected_hero_image: String(state?.selected_hero_image || "").trim(),
+      current_hero_image: String(state?.current_hero_image || "").trim(),
+      active_criteria_profile: String(state?.active_criteria_profile || "").trim(),
+      shortlist_basis: String(state?.shortlist_basis || "").trim(),
+      current_hero_rank: state?.current_hero_rank === null || state?.current_hero_rank === undefined || state?.current_hero_rank === "" ? null : Number(state.current_hero_rank),
+      current_hero_outside_top_three: !!state?.current_hero_outside_top_three,
+      selected_reason_codes: normalizedCodes,
+      optional_note: String(state?.optional_note || "").trim(),
+      criteria_refinement_signal: !!state?.criteria_refinement_signal,
+      image_set_limitation_signal: !!state?.image_set_limitation_signal,
+      metadata_issue_signal: !!state?.metadata_issue_signal,
+      diagnostics_issue_signal: !!state?.diagnostics_issue_signal
+    };
+  };
+
+  const setSaveButtonState = (node, state) => {
+    const panel = createForm(node);
+    const btn = panel ? panel.querySelector("[data-rationale-save]") : null;
+    if (!btn) return;
+
+    btn.classList.remove("is-saving", "is-saved");
+    btn.disabled = false;
+
+    if (state === "saving") {
+      btn.textContent = "Saving...";
+      btn.disabled = true;
+      btn.classList.add("is-saving");
+      return;
+    }
+    if (state === "saved") {
+      btn.textContent = "Saved ✓";
+      btn.classList.add("is-saved");
+      return;
+    }
+    if (state === "changes") {
+      btn.textContent = "Save changes";
+      return;
+    }
+    btn.textContent = "Save rationale";
+  };
+
   const hydrateForm = (node, rationale) => {
     const panel = createForm(node);
     if (!panel) return;
@@ -454,7 +501,10 @@ document.addEventListener("DOMContentLoaded", () => {
 
     node._rationale = data.rationale || null;
     hydrateForm(node, node._rationale);
+    node._rationaleBaseline = canonicalizeRationaleState({ ...(node._rationale || {}), itemId: Number(itemId || 0) });
+    node._rationaleSaving = false;
     feedback.textContent = node._rationale ? "Loaded saved rationale." : "No saved rationale yet.";
+    setSaveButtonState(node, node._rationale ? "saved" : "idle");
     const toggle = node.querySelector("[data-rationale-toggle]");
     if (toggle) toggle.textContent = node._rationale ? "View / edit rationale" : "Record rationale";
   };
@@ -477,6 +527,8 @@ document.addEventListener("DOMContentLoaded", () => {
   };
 
   const saveRationale = async node => {
+    if (node._rationaleSaving) return;
+
     const itemId = Number(node.dataset.rationaleItemId || 0);
     const panel = createForm(node);
     const feedback = panel.querySelector("[data-rationale-feedback]");
@@ -502,21 +554,66 @@ document.addEventListener("DOMContentLoaded", () => {
       ...signals
     };
 
-    feedback.textContent = "Saving rationale…";
-    const res = await fetch(`${baseUrl}/admin/hero-rationale.php`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(payload)
-    });
-    const data = await res.json();
-    if (!res.ok || !data.ok) throw new Error(data.error || "Failed to save rationale");
-    await fetchRationale(node);
-    applyStatusFromState(node);
-    feedback.textContent = "Rationale saved.";
+    const normalizedCurrent = canonicalizeRationaleState(payload);
+    const baseline = node._rationaleBaseline || canonicalizeRationaleState({ itemId });
+    if (JSON.stringify(normalizedCurrent) === JSON.stringify(baseline)) {
+      feedback.textContent = "No changes to save.";
+      setSaveButtonState(node, "saved");
+      return;
+    }
+
+    node._rationaleSaving = true;
+    setSaveButtonState(node, "saving");
+    feedback.textContent = "Saving rationale...";
+
+    try {
+      const res = await fetch(`${baseUrl}/admin/hero-rationale.php`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload)
+      });
+      const data = await res.json();
+      if (!res.ok || !data.ok) throw new Error(data.error || "Failed to save rationale");
+
+      await fetchRationale(node);
+      applyStatusFromState(node);
+      feedback.textContent = data.message || "Rationale saved.";
+      setSaveButtonState(node, "saved");
+    } finally {
+      node._rationaleSaving = false;
+    }
   };
 
   rationaleNodes.forEach(node => {
     createForm(node);
+    const panel = node.querySelector("[data-rationale-panel]");
+    if (panel) {
+      const markDirty = () => {
+        if (node._rationaleSaving) return;
+        const shortlist = shortlistByItem.get(String(node.dataset.rationaleItemId || "")) || null;
+        const currentHero = shortlist?.current_hero || {};
+        const currentPayload = {
+          itemId: Number(node.dataset.rationaleItemId || 0),
+          selected_hero_image: String(node.dataset.currentHeroImage || currentHero.path || "").trim(),
+          current_hero_image: String(node.dataset.currentHeroImage || currentHero.path || "").trim(),
+          active_criteria_profile: shortlist?.active_criteria_profile || null,
+          shortlist_basis: shortlist?.shortlist_basis || null,
+          current_hero_rank: currentHero.current_hero_rank ?? null,
+          current_hero_outside_top_three: !!currentHero.current_hero_outside_top_three,
+          selected_reason_codes: Array.from(panel.querySelectorAll("[data-reason-code]:checked")).map(input => input.dataset.reasonCode),
+          optional_note: panel.querySelector("[data-rationale-note]").value,
+          criteria_refinement_signal: !!panel.querySelector('[data-signal-code="criteria_refinement_signal"]')?.checked,
+          image_set_limitation_signal: !!panel.querySelector('[data-signal-code="image_set_limitation_signal"]')?.checked,
+          metadata_issue_signal: !!panel.querySelector('[data-signal-code="metadata_issue_signal"]')?.checked,
+          diagnostics_issue_signal: !!panel.querySelector('[data-signal-code="diagnostics_issue_signal"]')?.checked
+        };
+        const current = canonicalizeRationaleState(currentPayload);
+        const baseline = node._rationaleBaseline || canonicalizeRationaleState({ itemId: current.itemId });
+        setSaveButtonState(node, JSON.stringify(current) === JSON.stringify(baseline) ? "saved" : "changes");
+      };
+      panel.addEventListener("input", markDirty);
+      panel.addEventListener("change", markDirty);
+    }
     fetchRationale(node).catch(err => {
       const panel = node.querySelector("[data-rationale-panel]");
       const feedback = panel ? panel.querySelector("[data-rationale-feedback]") : null;
@@ -543,6 +640,8 @@ document.addEventListener("DOMContentLoaded", () => {
         const panel = node.querySelector("[data-rationale-panel]");
         const feedback = panel ? panel.querySelector("[data-rationale-feedback]") : null;
         if (feedback) feedback.textContent = err.message || "Unable to save rationale.";
+        setSaveButtonState(node, "changes");
+        node._rationaleSaving = false;
       });
     });
   });


### PR DESCRIPTION
### Motivation
- The rationale panel confirmation was too subtle and allowed accidental double-saves, producing duplicate inactive history rows with identical content. 
- The intent is to provide obvious button-level feedback for save operations and to prevent creation of redundant history rows when a submitted rationale is materially identical to the active one.

### Description
- Frontend: enhanced `js/admin/hero.js` to add canonicalized state comparison, dirty-state tracking, and explicit save button states (`Saving...`, `Saved ✓`, `Save changes`), plus an in-flight guard to prevent duplicate POSTs and a frontend no-op when the form is unchanged. 
- Backend: added `sw_hero_rationale_normalize_for_compare()` and updated `sw_hero_rationale_save()` in `inc/hero/rationale.php` to compare the normalized incoming payload against the active rationale and return the existing `rationale_id` with `unchanged=true` instead of inserting a duplicate row when materially identical. 
- API: updated `admin/hero-rationale.php` POST response to surface `message: "No changes to save"` and an `unchanged` flag when the save was a no-op. 
- Styling: added scoped CSS in `css/admin/hero.css` for disabled/saving/saved button visuals to make feedback visible at the button level.
- Existing validation and behavior were preserved, including reason-code validation and the supersede+insert flow when submissions differ materially.

### Testing
- Ran `php -l inc/hero/rationale.php` and it reported no syntax errors. 
- Ran `php -l admin/hero-rationale.php` and it reported no syntax errors. 
- Ran `node --check js/admin/hero.js` and it reported no syntax errors. 
- Ran `git diff --check` and no new whitespace or diff issues were reported.

Changed files:
- `js/admin/hero.js`
- `css/admin/hero.css`
- `inc/hero/rationale.php`
- `admin/hero-rationale.php`

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06649377a88324adca694d62ddf71d)