### PR TITLE
Stage 3AH: refine saved rationale collapse and view/edit toggle behaviour

### DIFF
--- a/css/admin/hero.css
+++ b/css/admin/hero.css
@@ -368,6 +368,24 @@
     color: #cbd5e1;
 }
 
+.hero-rationale__compact {
+    margin-top: 8px;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+}
+
+.hero-rationale__compact-pill {
+    display: inline-flex;
+    align-items: center;
+    padding: 3px 8px;
+    border-radius: 999px;
+    border: 1px solid rgba(134,239,172,0.45);
+    background: rgba(22,101,52,0.18);
+    color: #bbf7d0;
+    font-size: 0.68rem;
+}
+
 .hero-rationale__group,
 .hero-rationale__signals {
     display: grid;

--- a/js/admin/hero.js
+++ b/js/admin/hero.js
@@ -379,6 +379,8 @@ document.addEventListener("DOMContentLoaded", () => {
       if (node !== current) {
         const panel = node.querySelector("[data-rationale-panel]");
         if (panel) panel.hidden = true;
+        const toggle = node.querySelector("[data-rationale-toggle]");
+        if (toggle) toggle.textContent = node._rationale ? "View / edit rationale" : "Record rationale";
       }
     });
   };
@@ -427,6 +429,61 @@ document.addEventListener("DOMContentLoaded", () => {
 
     panel.dataset.formBuilt = "1";
     return panel;
+  };
+
+  const getCompactSummaryNode = node => {
+    let summary = node.querySelector("[data-rationale-compact]");
+    if (summary) return summary;
+
+    const statusRow = node.querySelector(".hero-rationale__status-row");
+    if (!statusRow) return null;
+
+    summary = document.createElement("div");
+    summary.className = "hero-rationale__compact";
+    summary.setAttribute("data-rationale-compact", "");
+    statusRow.insertAdjacentElement("afterend", summary);
+    return summary;
+  };
+
+  const updateToggleLabel = node => {
+    const toggle = node.querySelector("[data-rationale-toggle]");
+    const panel = node.querySelector("[data-rationale-panel]");
+    if (!toggle || !panel) return;
+
+    if (!panel.hidden) {
+      toggle.textContent = "Hide rationale";
+      return;
+    }
+    toggle.textContent = node._rationale ? "View / edit rationale" : "Record rationale";
+  };
+
+  const updateCompactSummary = node => {
+    const summary = getCompactSummaryNode(node);
+    if (!summary) return;
+
+    if (!node._rationale) {
+      summary.innerHTML = "";
+      summary.hidden = true;
+      return;
+    }
+
+    const savedReasons = Array.isArray(node._rationale.selected_reason_codes) ? node._rationale.selected_reason_codes.length : 0;
+    const tags = [`<span class="hero-rationale__compact-pill">Reasons: ${savedReasons}</span>`];
+
+    if (node._rationale.criteria_refinement_signal) tags.push('<span class="hero-rationale__compact-pill">Criteria review</span>');
+    if (node._rationale.image_set_limitation_signal) tags.push('<span class="hero-rationale__compact-pill">Image-set limitation</span>');
+    if (node._rationale.metadata_issue_signal) tags.push('<span class="hero-rationale__compact-pill">Metadata/category issue</span>');
+    if (node._rationale.diagnostics_issue_signal) tags.push('<span class="hero-rationale__compact-pill">Diagnostics/ranking issue</span>');
+
+    summary.innerHTML = tags.join("");
+    summary.hidden = false;
+  };
+
+  const setPanelOpen = (node, open) => {
+    const panel = node.querySelector("[data-rationale-panel]");
+    if (!panel) return;
+    panel.hidden = !open;
+    updateToggleLabel(node);
   };
 
   const canonicalizeRationaleState = state => {
@@ -505,8 +562,8 @@ document.addEventListener("DOMContentLoaded", () => {
     node._rationaleSaving = false;
     feedback.textContent = node._rationale ? "Loaded saved rationale." : "No saved rationale yet.";
     setSaveButtonState(node, node._rationale ? "saved" : "idle");
-    const toggle = node.querySelector("[data-rationale-toggle]");
-    if (toggle) toggle.textContent = node._rationale ? "View / edit rationale" : "Record rationale";
+    updateCompactSummary(node);
+    setPanelOpen(node, !node._rationale);
   };
 
   const applyStatusFromState = node => {
@@ -579,6 +636,12 @@ document.addEventListener("DOMContentLoaded", () => {
       applyStatusFromState(node);
       feedback.textContent = data.message || "Rationale saved.";
       setSaveButtonState(node, "saved");
+      setTimeout(() => {
+        if (node._rationaleSaving) return;
+        const btn = panel.querySelector("[data-rationale-save]");
+        if (btn && btn.textContent === "Save changes") return;
+        setPanelOpen(node, false);
+      }, 800);
     } finally {
       node._rationaleSaving = false;
     }
@@ -629,7 +692,7 @@ document.addEventListener("DOMContentLoaded", () => {
         if (!panel) return;
         const willOpen = panel.hidden;
         closeAllRationalePanels(node);
-        panel.hidden = !willOpen;
+        setPanelOpen(node, willOpen);
       });
     }
 


### PR DESCRIPTION
### Motivation
- Fix UX where a saved rationale left the full panel open, making the toggle button appear to do nothing.  
- Ensure saved rationales present a compact summary by default while keeping full edit accessibility.  
- Preserve existing Stage 3AG protections (dirty tracking, no-op saves, and duplicate-save guarding) and limit changes to the allowed UI files.

### Description
- Add a compact saved-state summary and scoped styles (`hero-rationale__compact`, `hero-rationale__compact-pill`) to `css/admin/hero.css` and create/manage that node from JS.  
- Introduce `setPanelOpen`, `updateCompactSummary`, and `updateToggleLabel` plus `getCompactSummaryNode` to centralize open/close behavior and toggle label semantics in `js/admin/hero.js`.  
- Change load/save flow so `fetchRationale` collapses saved rationales by default (`setPanelOpen(node, !node._rationale)`), update the toggle text to `View / edit rationale` or `Record rationale` when collapsed and `Hide rationale` when open, and auto-collapse after a short delay following a successful save when no unsaved edits are present.  
- Ensure `closeAllRationalePanels` resets toggle labels for other cards and do not modify backend, schema, or unrelated admin/frontend code; only `js/admin/hero.js` and `css/admin/hero.css` were changed.

### Testing
- Ran `node --check js/admin/hero.js` and it completed successfully.  
- Ran `git diff --check` and it completed successfully.  
- Verified no PHP/backend files were modified so `php -l` was not required, and confirmed no schema/migration or public frontend files were changed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0668f5e28c8324ab9e16034659c16d)