### PR TITLE
Fix rationale panel collapse behavior in Hero Manager

### DIFF
--- a/css/admin/hero.css
+++ b/css/admin/hero.css
@@ -363,6 +363,11 @@
     gap: 8px;
 }
 
+
+.hero-rationale__panel[hidden] {
+    display: none;
+}
+
 .hero-rationale__panel-state {
     font-size: 0.72rem;
     color: #cbd5e1;

--- a/js/admin/hero.js
+++ b/js/admin/hero.js
@@ -428,6 +428,7 @@ document.addEventListener("DOMContentLoaded", () => {
     });
 
     panel.dataset.formBuilt = "1";
+    panel.hidden = true;
     return panel;
   };
 


### PR DESCRIPTION
### Motivation
- The saved-state UI for the Human Override Rationale panel was rendering the full editable form body visible on page load even when a saved rationale should show only the compact summary and a “View / edit rationale” toggle. 
- The goal is to ensure the form body remains collapsed for saved rationale state and only opens when the user clicks the toggle, while preserving existing save/dirty-state logic. 

### Description
- Initialize the rationale form panel as hidden by setting `panel.hidden = true` when the form DOM is built in `js/admin/hero.js`, so it does not flash open before state hydration. 
- Add a scoped CSS rule `.hero-rationale__panel[hidden] { display: none; }` in `css/admin/hero.css` so the `[hidden]` attribute is effective despite the panel’s `display: flex` styles. 
- Preserve existing Stage 3AG/3AH behaviors including dirty-state detection, save feedback, compact summary rendering, and toggle label text changes; the code now correctly collapses after successful save when no unsaved changes exist.

### Testing
- Ran `node --check js/admin/hero.js` which succeeded without syntax errors. 
- Ran `git diff --check` as part of validation which produced no problems; only `js/admin/hero.js` and `css/admin/hero.css` were modified and no backend/schema files were changed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06743010c48324938b4292c440bc2d)