### PR TITLE
Redesign Hero Manager desktop card grid layout

### DIFF
--- a/css/admin/hero.css
+++ b/css/admin/hero.css
@@ -80,8 +80,8 @@
 
 .hero-list .hero-card {
     display: grid;
-    grid-template-columns: minmax(160px, 220px) minmax(0, 1fr);
-    gap: 12px;
+    grid-template-columns: minmax(200px, 250px) minmax(240px, 320px) minmax(260px, 1fr);
+    gap: 12px 14px;
     align-items: start;
 }
 
@@ -92,7 +92,7 @@
 
 .hero-list .hero-card__left {
     grid-column: 1;
-    grid-row: 1 / span 4;
+    grid-row: 1;
     min-width: 0;
 }
 
@@ -171,7 +171,7 @@
 .hero-list .hero-card__images {
     grid-column: 2;
     width: 100%;
-    max-width: 360px;
+    max-width: none;
     margin-top: 0;
     margin-left: 0;
 }
@@ -250,10 +250,11 @@
 }
 
 .hero-list .hero-card__actions {
-    grid-column: 2;
+    grid-column: 3;
     margin-top: 0;
     margin-left: 0;
     align-self: start;
+    justify-content: flex-start;
 }
 
 .hero-empty {
@@ -271,15 +272,16 @@
 @media (min-width: 1100px) {
     .hero-list .hero-card {
         grid-template-columns:
-            minmax(220px, 1fr)
-            minmax(260px, 360px)
-            minmax(280px, 1fr)
-            minmax(150px, 180px);
+            minmax(220px, 0.95fr)
+            minmax(250px, 0.9fr)
+            minmax(320px, 1.35fr)
+            minmax(170px, 0.55fr);
+        gap: 14px 16px;
     }
 
     .hero-list .hero-card__left {
         grid-column: 1;
-        grid-row: 1 / span 2;
+        grid-row: 1;
     }
 
     .hero-list .hero-card__images {
@@ -290,6 +292,7 @@
     .hero-list .hero-card__insights {
         grid-column: 3;
         max-width: none;
+        min-width: 0;
     }
 
     .hero-list .hero-card__actions {
@@ -300,6 +303,27 @@
     .hero-list .hero-card > .context-note {
         grid-column: 4;
         grid-row: 2;
+    }
+}
+
+@media (min-width: 720px) and (max-width: 1099px) {
+    .hero-list .hero-card {
+        grid-template-columns: minmax(210px, 1fr) minmax(230px, 1fr);
+        gap: 12px 14px;
+    }
+
+    .hero-list .hero-card__left {
+        grid-column: 1;
+    }
+
+    .hero-list .hero-card__images {
+        grid-column: 2;
+    }
+
+    .hero-list .hero-card__insights,
+    .hero-list .hero-card__actions,
+    .hero-list .hero-card > .context-note {
+        grid-column: 1 / -1;
     }
 }
 
@@ -361,6 +385,7 @@
     display: flex;
     flex-direction: column;
     gap: 8px;
+    width: 100%;
 }
 
 
@@ -394,7 +419,7 @@
 .hero-rationale__group,
 .hero-rationale__signals {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
     gap: 6px 10px;
 }
 
@@ -415,6 +440,7 @@
 
 .hero-rationale__field textarea {
     width: 100%;
+    min-height: 96px;
     background: rgba(15,23,42,0.8);
     border: 1px solid rgba(148,163,235,0.3);
     border-radius: 10px;
@@ -435,12 +461,12 @@
 }
 
 .hero-list .hero-card__insights {
-    grid-column: 2;
-    max-width: 360px;
+    grid-column: 3;
+    max-width: none;
 }
 
 .hero-list .hero-card > .context-note {
-    grid-column: 2;
+    grid-column: 3;
     margin-top: 0;
 }
 


### PR DESCRIPTION
### Motivation
- The Hero Manager desktop card left large unused horizontal space, compressing product identity, image comparison, shortlist preview and rationale into a narrow central column.
- The rationale form became tall and narrow when opened on desktop, making checkbox labels and the notes textarea hard to read.
- The goal is an information-architecture/layout refinement to distribute content across product info, images, review/rationale and actions while preserving all existing functionality and data flows.

### Description
- Reworked the card grid in `css/admin/hero.css` to a multi-column layout that maps product info, images, review/shortlist/rationale, and actions into a horizontal 3–4 column grid on wide screens.
- Added a medium breakpoint (`720px–1099px`) to switch to a simpler two-column layout so rationale and actions remain readable before mobile stacking.
- Increased rationale form ergonomics by widening the checkbox grid (`minmax(240px, 1fr)`) and adding a `min-height` to the notes textarea so opened panels are not overly narrow/tall.
- Changes are CSS-only (modified file: `css/admin/hero.css`) and make no backend, schema, ranking, authority, or persistence logic changes.

### Testing
- Ran `git diff --check` which reported clean; the repo shows only `css/admin/hero.css` modified (passed).
- Committed the change with `git commit` which succeeded and produced a single-file commit for `css/admin/hero.css` (passed).
- Skipped `php -l` and `node --check` because no PHP or JS files were modified (not applicable).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a068119eb008324a3ab2e7bbadaf6a3)