### PR TITLE
Refine Hero Manager layout density and decision hierarchy

### DIFF
--- a/admin/hero-manager.php
+++ b/admin/hero-manager.php
@@ -545,7 +545,7 @@ admin_layout_start("Hero Manager");
                             <span class="hero-badge">
                                 <?= $score !== null ? "Score: " . number_format($score, 1) : "No score" ?>
                             </span>
-                            <span class="hero-badge"><?= $orientLabel ?></span>
+                            <span class="hero-badge hero-badge--orientation<?= $orient === 'S' ? ' is-square' : '' ?>"><?= $orientLabel ?></span>
 
                             <?php if ($override): ?>
                                 <span class="hero-badge hero-badge--override">Override active</span>
@@ -563,6 +563,20 @@ admin_layout_start("Hero Manager");
                                 <span class="hero-badge hero-badge--missing">Missing (override)</span>
                             <?php endif; ?>
 
+                        </div>
+
+                        <div class="hero-card__actions" aria-label="Hero item actions">
+                            <a class="btn btn-primary" href="hero-edit.php?id=<?= $itemId ?>">
+                                <span class="btn__dot"></span> Edit hero
+                            </a>
+
+                            <a class="btn btn-ghost" href="hero-manager.php?recalc=<?= $itemId ?>">
+                                Recalculate
+                            </a>
+                        </div>
+                        <div class="context-note">
+                            Recalculate runs the automatic selector only.
+                            It does not override manual hero selections.
                         </div>
                     </div>
                 </div>
@@ -649,7 +663,7 @@ admin_layout_start("Hero Manager");
                         data-current-hero-source="<?= $currentHeroSource ?>"
                     >
                         <button class="hero-candidates__toggle">
-                            ▸ Candidate images (ranked, explainable)
+                            ▸ Candidate images
                         </button>
                         <div class="hero-candidates__panel" hidden>
                             <div class="hero-candidates__placeholder">
@@ -657,21 +671,6 @@ admin_layout_start("Hero Manager");
                             </div>
                         </div>
                     </div>
-                </div>
-
-                <!-- Buttons -->
-                <div class="hero-card__actions">
-                    <a class="btn btn-primary" href="hero-edit.php?id=<?= $itemId ?>">
-                        <span class="btn__dot"></span> Edit hero
-                    </a>
-
-                    <a class="btn btn-ghost" href="hero-manager.php?recalc=<?= $itemId ?>">
-                        Recalculate
-                    </a>
-                </div>
-                <div class="context-note">
-                    Recalculate runs the automatic selector only.
-                    It does not override manual hero selections.
                 </div>
 
             </section>

--- a/css/admin/hero.css
+++ b/css/admin/hero.css
@@ -80,7 +80,7 @@
 
 .hero-list .hero-card {
     display: grid;
-    grid-template-columns: minmax(200px, 250px) minmax(240px, 320px) minmax(260px, 1fr);
+    grid-template-columns: minmax(240px, 1.05fr) minmax(250px, 0.95fr) minmax(320px, 1.2fr);
     gap: 12px 14px;
     align-items: start;
 }
@@ -244,17 +244,15 @@
 
 .hero-card__actions {
     display: flex;
-    flex-wrap: wrap;
+    flex-direction: column;
+    align-items: flex-start;
     gap: 8px;
-    margin-top: 4px;
+    margin-top: 10px;
 }
 
-.hero-list .hero-card__actions {
-    grid-column: 3;
-    margin-top: 0;
-    margin-left: 0;
-    align-self: start;
-    justify-content: flex-start;
+.hero-card__actions .btn {
+    min-width: 132px;
+    justify-content: center;
 }
 
 .hero-empty {
@@ -272,10 +270,9 @@
 @media (min-width: 1100px) {
     .hero-list .hero-card {
         grid-template-columns:
-            minmax(220px, 0.95fr)
-            minmax(250px, 0.9fr)
-            minmax(320px, 1.35fr)
-            minmax(170px, 0.55fr);
+            minmax(240px, 1.05fr)
+            minmax(250px, 0.95fr)
+            minmax(340px, 1.25fr);
         gap: 14px 16px;
     }
 
@@ -296,13 +293,12 @@
     }
 
     .hero-list .hero-card__actions {
-        grid-column: 4;
-        grid-row: 1;
+        margin-top: 10px;
     }
 
     .hero-list .hero-card > .context-note {
-        grid-column: 4;
-        grid-row: 2;
+        grid-column: 3;
+        grid-row: auto;
     }
 }
 
@@ -320,8 +316,15 @@
         grid-column: 2;
     }
 
-    .hero-list .hero-card__insights,
-    .hero-list .hero-card__actions,
+    .hero-list .hero-card__insights {
+        grid-column: 1 / -1;
+    }
+
+    .hero-list .hero-card__actions {
+        flex-direction: row;
+        flex-wrap: wrap;
+    }
+
     .hero-list .hero-card > .context-note {
         grid-column: 1 / -1;
     }
@@ -336,7 +339,6 @@
     .hero-list .hero-card__left,
     .hero-list .hero-card__images,
     .hero-list .hero-card__insights,
-    .hero-list .hero-card__actions,
     .hero-list .hero-card > .context-note {
         width: 100%;
         max-width: none;
@@ -732,4 +734,34 @@
     border-color: rgba(74,222,128,0.7);
     background: rgba(22,101,52,0.28);
     color: #bbf7d0;
+}
+
+.hero-badge--orientation.is-square {
+    display: none;
+}
+
+.hero-card__meta .context-note {
+    margin-top: 0;
+    max-width: 32ch;
+}
+
+.hero-candidates__toggle {
+    width: auto;
+    gap: 6px;
+    padding: 6px 10px;
+    margin: 8px;
+    border: 1px solid rgba(148, 163, 235, 0.42);
+    border-radius: 999px;
+    background: rgba(15, 23, 42, 0.56);
+    font-size: 0.74rem;
+    font-weight: 600;
+}
+
+.hero-candidates__toggle:hover,
+.hero-candidates__toggle:focus {
+    background: rgba(148, 163, 235, 0.16);
+}
+
+.hero-candidates__panel {
+    border-top: 1px solid rgba(148, 163, 235, 0.2);
 }

--- a/js/admin/hero.js
+++ b/js/admin/hero.js
@@ -84,13 +84,13 @@ document.addEventListener("DOMContentLoaded", () => {
       // toggle closed
       if (!panel.hasAttribute("hidden")) {
         panel.hidden = true;
-        btn.textContent = "▸ Candidate images (ranked, explainable)";
+        btn.textContent = "▸ Candidate images";
         return;
       }
 
       // toggle open
       panel.hidden = false;
-      btn.textContent = "▾ Candidate images (ranked, explainable)";
+      btn.textContent = "▾ Candidate images";
 
       // already loaded
       if (panel.dataset.loaded) return;


### PR DESCRIPTION
### Motivation
- Reduce wasted desktop whitespace and remove the right-hand actions column so the card hierarchy favors product identity, the hero decision, then shortlist/rationale.
- Place direct actions (Edit / Recalculate) under product identity to make actions contextually available without a separate column.
- Visually de-emphasise non-essential metadata (hide the `Square` orientation pill) and reduce the candidate-toggle visual weight while preserving existing behaviour.
- Preserve all backend behaviour and data contracts for hero selection, shortlist ranking, rationale persistence, and scoring.

### Description
- Moved the action buttons and context note into the product identity area by adjusting markup in `admin/hero-manager.php` so `Edit hero` and `Recalculate` are rendered beneath the badges.
- Added a conditional orientation class on the orientation badge in `admin/hero-manager.php` to allow hiding the `Square` case without removing orientation data.
- Reworked desktop grid and action layout in `css/admin/hero.css` to a 3-column structure, tightened column widths, moved the context note, hid `.hero-badge--orientation.is-square`, and restyled `.hero-card__actions` and `.hero-candidates__toggle` to reduce visual weight.
- Shortened the candidate toggle label in `js/admin/hero.js` from "Candidate images (ranked, explainable)" to "Candidate images" while leaving expand/collapse and data-loading logic unchanged.
- Changes are scoped to the allowed files only: `admin/hero-manager.php`, `css/admin/hero.css`, and `js/admin/hero.js`, and do not modify rationale backends, shortlist endpoints, database schema, or public/frontend files.

### Testing
- `php -l admin/hero-manager.php` was run and reported no syntax errors.
- `node --check js/admin/hero.js` was run and reported no syntax errors.
- `git diff --check` (whitespace/check) was run and returned no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06889b95888324882c34c3e0871530)