### PR TITLE
Stage 3AL: widen hero-manager review trays and add horizontal candidate browser

### DIFF
--- a/admin/hero-manager.php
+++ b/admin/hero-manager.php
@@ -639,6 +639,9 @@ admin_layout_start("Hero Manager");
                     <div class="hero-shortlist-preview" data-shortlist-item-id="<?= $itemId ?>">
                         <div class="hero-shortlist-preview__state">Loading shortlist…</div>
                     </div>
+                </div>
+
+                <div class="hero-card__review-trays">
                     <div
                         class="hero-rationale"
                         data-rationale-item-id="<?= $itemId ?>"

--- a/css/admin/hero.css
+++ b/css/admin/hero.css
@@ -765,3 +765,109 @@
 .hero-candidates__panel {
     border-top: 1px solid rgba(148, 163, 235, 0.2);
 }
+
+.hero-card__review-trays {
+    grid-column: 1 / -1;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    min-width: 0;
+}
+
+.hero-candidates__panel {
+    display: grid;
+    grid-auto-flow: column;
+    grid-auto-columns: minmax(260px, 30%);
+    gap: 12px;
+    overflow-x: auto;
+    overflow-y: hidden;
+    overscroll-behavior-x: contain;
+    scroll-snap-type: x proximity;
+    padding: 12px;
+}
+
+.hero-candidates__panel[hidden] {
+    display: none;
+}
+
+.hero-candidates__panel > .hero-candidates__placeholder {
+    grid-column: 1 / -1;
+}
+
+.candidate-row {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    min-width: 0;
+    border: 1px solid rgba(148, 163, 235, 0.35);
+    border-radius: 12px;
+    padding: 10px;
+    background: rgba(15, 23, 42, 0.5);
+    scroll-snap-align: start;
+}
+
+.candidate-header {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 6px;
+    font-size: 0.9rem;
+    font-weight: 700;
+}
+
+.candidate-image {
+    border-radius: 10px;
+    border: 1px solid rgba(148, 163, 235, 0.35);
+    background: #020617;
+    min-height: 220px;
+    max-height: 340px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    overflow: hidden;
+}
+
+.candidate-image img {
+    width: 100%;
+    height: 100%;
+    object-fit: contain;
+}
+
+.candidate-explain {
+    font-size: 0.8rem;
+    color: #e2e8f0;
+    display: grid;
+    gap: 4px;
+}
+
+.candidate-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+}
+
+@media (min-width: 1100px) {
+    .hero-card__review-trays {
+        grid-column: 2 / -1;
+    }
+}
+
+@media (min-width: 720px) and (max-width: 1099px) {
+    .hero-card__review-trays {
+        grid-column: 1 / -1;
+    }
+
+    .hero-candidates__panel {
+        grid-auto-columns: minmax(260px, 45%);
+    }
+}
+
+@media (max-width: 719px) {
+    .hero-card__review-trays {
+        width: 100%;
+    }
+
+    .hero-candidates__panel {
+        grid-auto-columns: minmax(220px, 86%);
+    }
+}


### PR DESCRIPTION
### Motivation
- Expanded candidate images and rationale were constrained to a narrow right column, forcing tall single-column stacks and excessive scrolling. 
- The goal is to allow expanded review content to use available desktop horizontal space so multiple candidates can be compared at once. 
- This change must be purely layout/interaction and must not alter backend semantics, scoring, rationale persistence, or selection/rejection behavior. 

### Description
- Move rationale and candidate sections into a new `hero-card__review-trays` wrapper in `admin/hero-manager.php` so expanded panels can span the card instead of being trapped in the right column. 
- Add scoped layout rules in `css/admin/hero.css` to implement a horizontal, scrollable candidate review tray using `grid-auto-flow: column`, `overflow-x: auto`, and `scroll-snap` with constrained `grid-auto-columns` so 2–3 candidate cards are visible at desktop widths. 
- Add card-level styles for `.candidate-row`, `.candidate-image`, `.candidate-explain`, and `.candidate-actions` to size images sensibly and preserve diagnostics layout while avoiding huge single-column images. 
- Preserve all existing behaviors and endpoints by not changing candidate rendering logic in `js/admin/hero.js`, and keep `Select as hero` / `Reject` links and rationale JS behavior unchanged; changed files: `admin/hero-manager.php`, `css/admin/hero.css`. 

### Testing
- Ran `php -l admin/hero-manager.php` and it returned "No syntax errors detected". 
- Ran `git diff --check` and it returned no whitespace/patch errors. 
- Verified that no backend rationale files, database/migration files, scoring/ranking/authority helpers, or public frontend files were modified.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a069021bb60832492dfb46397828508)