### PR TITLE
Fix manual hero selection flow in Hero Manager

### DIFF
--- a/admin/hero-edit.php
+++ b/admin/hero-edit.php
@@ -135,6 +135,8 @@ $heroRatio  = $item['hero_ratio'] !== null ? (float)$item['hero_ratio'] : null;
 $heroOrient = strtoupper(trim((string)($item['hero_orientation'] ?? '')));
 $chosen     = trim((string)($item['chosen_image'] ?? ''));
 $thumbsRaw  = (string)($item['thumbnails_json'] ?? '');
+$selectedFromQuery = trim((string)($_GET['select'] ?? ''));
+$selectedFromQueryValid = false;
 
 // --------------------------------------------------------
 // 2) Build candidate list (chosen_image + thumbnails_json)
@@ -166,6 +168,15 @@ if ($thumbsRaw !== '') {
     $parts = array_filter(array_map('trim', explode(';', $thumbsRaw)));
     foreach ($parts as $p) {
         $addCandidate($p, 'thumb');
+    }
+}
+
+if ($selectedFromQuery !== '') {
+    foreach ($candidates as $candidate) {
+        if ((string)$candidate['path'] === $selectedFromQuery) {
+            $selectedFromQueryValid = true;
+            break;
+        }
     }
 }
 
@@ -274,8 +285,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 ':img' => $overridePath,
             ]);
 
-            $flashMessage = 'Hero image overridden for item #' . $itemId . '.';
-            $flashType    = 'success';
+            header('Location: hero-manager.php?hero_saved=1&item_id=' . $itemId);
+            exit;
         }
 
     } elseif ($action === 'clear_override') {
@@ -327,6 +338,18 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 $overStmt = $pdo->prepare("SELECT chosen_image FROM hero_override WHERE itemId = :id");
 $overStmt->execute([':id' => $itemId]);
 $override = trim((string)$overStmt->fetchColumn());
+
+$effectiveOverride = $override;
+if ($selectedFromQueryValid) {
+    $effectiveOverride = $selectedFromQuery;
+    if ($flashMessage === '') {
+        $flashMessage = 'Candidate staged. Click “Save override” to apply this hero.';
+        $flashType = 'info';
+    }
+} elseif ($selectedFromQuery !== '' && $flashMessage === '') {
+    $flashMessage = 'Requested candidate was not found for this item.';
+    $flashType = 'error';
+}
 
 $activeHero = $override ?: $heroImage ?: $chosen;
 
@@ -445,7 +468,7 @@ admin_layout_start("Hero Editor");
     <!-- Candidate list + override / reject controls -->
     <form method="post" class="card">
         <input type="hidden" name="override_image" id="overrideImageInput"
-               value="<?= htmlspecialchars($override) ?>">
+               value="<?= htmlspecialchars($effectiveOverride) ?>">
 
         <h2 style="font-size:1.0rem;margin:0 0 10px;">All candidate images</h2>
 
@@ -460,8 +483,8 @@ admin_layout_start("Hero Editor");
                     $src        = $cand['source'];
                     $score      = $cand['score'];
                     $ratio      = $cand['ratio'];
-                    $isSelected = ($override !== '' && $override === $path)
-                        || ($override === '' && $heroImage !== '' && $heroImage === $path);
+                    $isSelected = ($effectiveOverride !== '' && $effectiveOverride === $path)
+                        || ($effectiveOverride === '' && $heroImage !== '' && $heroImage === $path);
                     $isBestAuto = ($bestPathForReject !== '' && $path === $bestPathForReject);
                     ?>
                     <article class="candidate-tile candidate<?= $isSelected ? ' candidate--selected' : '' ?>">

--- a/admin/hero-manager.php
+++ b/admin/hero-manager.php
@@ -205,6 +205,16 @@ if (!function_exists('sw_recalc_hero_for_item')) {
 $flashMessage = '';
 $flashType = 'info';
 
+if (!empty($_GET['hero_saved'])) {
+    $savedItemId = (int)($_GET['item_id'] ?? 0);
+    if ($savedItemId > 0) {
+        $flashMessage = 'Manual hero saved for item #' . $savedItemId . '.';
+    } else {
+        $flashMessage = 'Manual hero saved.';
+    }
+    $flashType = 'success';
+}
+
 if (!empty($_GET['recalc'])) {
     $id = (int)$_GET['recalc'];
     $res = sw_recalc_hero_for_item($pdo, $id);

--- a/js/admin/hero.js
+++ b/js/admin/hero.js
@@ -266,6 +266,7 @@ document.addEventListener("DOMContentLoaded", () => {
           const profile = product.active_criteria_profile || "—";
           const basis = product.shortlist_basis || "legacy_rank_placeholder";
           const challengeEndpoint = resolveChallengeUrl(product.challenge_endpoint, itemId);
+          const reviewHref = `${baseUrl}/admin/hero-edit.php?id=${encodeURIComponent(itemId)}`;
 
           clearNode(node);
 
@@ -289,7 +290,7 @@ document.addEventListener("DOMContentLoaded", () => {
             foot.appendChild(makeEl("span", "hero-shortlist-preview__pill", `Basis: ${safeText(basis)}`));
 
             const review = makeEl("a", "hero-shortlist-preview__action", "Review candidates");
-            review.href = challengeEndpoint;
+            review.href = reviewHref;
             foot.appendChild(review);
 
             return foot;


### PR DESCRIPTION
### Motivation
- Administrators were sent to a diagnostic/JSON endpoint when clicking “Review candidates” and could not reliably stage and save a manual hero selection. 
- The existing workflow did not reliably stage a candidate from the Hero Manager shortlist nor provide clear feedback after saving, causing manual selection failures for items like #80. 

### Description
- `admin/hero-edit.php` now honors a `?select=...` query parameter, validates that the requested image belongs to the current item’s candidate set, and stages it in the override hidden input so it is highlighted and ready to save. 
- Saving an override now persists `hero_override` and then redirects the user back to `admin/hero-manager.php` with a success indicator (`hero_saved=1&item_id=...`) to provide clear confirmation. 
- `admin/hero-manager.php` was updated to show a flash confirmation when a manual hero has just been saved. 
- `js/admin/hero.js` now routes the shortlist “Review candidates” action to the human-facing editor (`admin/hero-edit.php?id=...`) instead of the diagnostic/JSON endpoint. 
- Files changed: `admin/hero-edit.php`, `admin/hero-manager.php`, and `js/admin/hero.js`.

### Testing
- Ran PHP lint on changed files with `php -l admin/hero-edit.php` and `php -l admin/hero-manager.php`, and both reported no syntax errors. 
- Ran JavaScript syntax check with `node --check js/admin/hero.js`, which completed without errors. 
- Ran `git diff --check` and it reported no whitespace or diff-check issues. 
- All automated checks passed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06b0ec390083249644b48cb90eff04)