### PR TITLE
Add staged override UI for hero selection with client-side preview and save redirect

### DIFF
--- a/admin/hero-edit.php
+++ b/admin/hero-edit.php
@@ -135,6 +135,8 @@ $heroRatio  = $item['hero_ratio'] !== null ? (float)$item['hero_ratio'] : null;
 $heroOrient = strtoupper(trim((string)($item['hero_orientation'] ?? '')));
 $chosen     = trim((string)($item['chosen_image'] ?? ''));
 $thumbsRaw  = (string)($item['thumbnails_json'] ?? '');
+$selectedFromQuery = trim((string)($_GET['select'] ?? ''));
+$selectedFromQueryValid = false;
 
 // --------------------------------------------------------
 // 2) Build candidate list (chosen_image + thumbnails_json)
@@ -166,6 +168,15 @@ if ($thumbsRaw !== '') {
     $parts = array_filter(array_map('trim', explode(';', $thumbsRaw)));
     foreach ($parts as $p) {
         $addCandidate($p, 'thumb');
+    }
+}
+
+if ($selectedFromQuery !== '') {
+    foreach ($candidates as $candidate) {
+        if ((string)$candidate['path'] === $selectedFromQuery) {
+            $selectedFromQueryValid = true;
+            break;
+        }
     }
 }
 
@@ -274,8 +285,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 ':img' => $overridePath,
             ]);
 
-            $flashMessage = 'Hero image overridden for item #' . $itemId . '.';
-            $flashType    = 'success';
+            header('Location: hero-manager.php?hero_saved=1&item_id=' . $itemId);
+            exit;
         }
 
     } elseif ($action === 'clear_override') {
@@ -328,6 +339,18 @@ $overStmt = $pdo->prepare("SELECT chosen_image FROM hero_override WHERE itemId =
 $overStmt->execute([':id' => $itemId]);
 $override = trim((string)$overStmt->fetchColumn());
 
+$effectiveOverride = $override;
+if ($selectedFromQueryValid) {
+    $effectiveOverride = $selectedFromQuery;
+    if ($flashMessage === '') {
+        $flashMessage = 'Candidate staged. Click “Save override” to apply this hero.';
+        $flashType = 'info';
+    }
+} elseif ($selectedFromQuery !== '' && $flashMessage === '') {
+    $flashMessage = 'Requested candidate was not found for this item.';
+    $flashType = 'error';
+}
+
 $activeHero = $override ?: $heroImage ?: $chosen;
 
 // Label for stored hero orientation
@@ -340,6 +363,8 @@ if ($heroOrient === 'L') {
 
 // Best candidate path for "Reject auto choice" button
 $bestPathForReject = $bestCandidate ? $bestCandidate['path'] : '';
+$stagedLabel = $effectiveOverride !== '' ? $effectiveOverride : 'No candidate selected';
+$stagedStatus = $effectiveOverride !== '' ? 'Ready to save' : 'Select a candidate, then save override';
 // --------------------------------------------------------
 // 6) Render layout
 // --------------------------------------------------------
@@ -443,9 +468,39 @@ admin_layout_start("Hero Editor");
     </section>
 
     <!-- Candidate list + override / reject controls -->
-    <form method="post" class="card">
+    <form method="post" class="card hero-override-form" id="heroOverrideForm">
         <input type="hidden" name="override_image" id="overrideImageInput"
-               value="<?= htmlspecialchars($override) ?>">
+               value="<?= htmlspecialchars($effectiveOverride) ?>">
+        <input type="hidden" name="reject_image" value="<?= htmlspecialchars($bestPathForReject) ?>">
+
+        <section class="hero-override-summary" data-override-summary>
+            <h2>Selected override candidate</h2>
+            <div class="hero-override-summary__body">
+                <div class="hero-override-summary__preview hero-slot__imgwrap" data-override-preview-wrap>
+                    <?php if ($effectiveOverride !== ''): ?>
+                        <?= admin_render_thumbnail_safe($effectiveOverride, "$itemName – staged override") ?>
+                    <?php else: ?>
+                        <span class="hero-slot__empty" data-override-preview-empty>No candidate selected</span>
+                    <?php endif; ?>
+                </div>
+                <div class="hero-override-summary__meta">
+                    <div class="hero-override-summary__path" data-override-path><?= htmlspecialchars($stagedLabel) ?></div>
+                    <div class="hero-override-summary__status" data-override-status><?= htmlspecialchars($stagedStatus) ?></div>
+                    <div class="hero-override-summary__actions">
+                        <button type="submit" name="action" value="save_override" class="btn btn-primary" data-save-override>
+                            <span class="btn__dot"></span>
+                            Save override
+                        </button>
+                        <?php if ($bestPathForReject !== ''): ?>
+                            <button type="submit" name="action" value="reject_auto" class="btn btn-danger">
+                                Reject auto choice
+                            </button>
+                        <?php endif; ?>
+                        <a href="hero-manager.php" class="btn btn-ghost">Back to Hero Manager</a>
+                    </div>
+                </div>
+            </div>
+        </section>
 
         <h2 style="font-size:1.0rem;margin:0 0 10px;">All candidate images</h2>
 
@@ -454,19 +509,20 @@ admin_layout_start("Hero Editor");
                 No candidate images found from <code>chosen_image</code> or <code>thumbnails_json</code>.
             </p>
         <?php else: ?>
-            <div class="card-grid">
+            <div class="card-grid card-grid--candidates">
                 <?php foreach ($candidates as $cand):
                     $path       = $cand['path'];
                     $src        = $cand['source'];
                     $score      = $cand['score'];
                     $ratio      = $cand['ratio'];
-                    $isSelected = ($override !== '' && $override === $path)
-                        || ($override === '' && $heroImage !== '' && $heroImage === $path);
-                    $isBestAuto = ($bestPathForReject !== '' && $path === $bestPathForReject);
+                    $isSelected = ($effectiveOverride !== '' && $effectiveOverride === $path)
+                        || ($effectiveOverride === '' && $heroImage !== '' && $heroImage === $path);
                     ?>
-                    <article class="candidate-tile candidate<?= $isSelected ? ' candidate--selected' : '' ?>">
+                    <article class="candidate-tile candidate<?= $isSelected ? ' candidate--selected' : '' ?>" data-candidate-card data-candidate-path="<?= htmlspecialchars($path) ?>" data-is-active-hero="<?= ($activeHero === $path) ? '1' : '0' ?>" data-is-stored-hero="<?= ($heroImage === $path) ? '1' : '0' ?>">
                         <div class="hero-slot__label">
                             <span><?= $src === 'chosen' ? 'Chosen image' : 'Thumbnail' ?></span>
+                            <?php if ($activeHero === $path): ?><span class="hero-badge hero-badge--manual">Active hero</span><?php endif; ?>
+                            <?php if ($heroImage === $path): ?><span class="hero-badge">Stored hero_image</span><?php endif; ?>
                             <span class="hero-slot__tag">
                                 <?= $src === 'chosen' ? 'Primary' : 'Alt' ?>
                             </span>
@@ -477,8 +533,8 @@ admin_layout_start("Hero Editor");
                         </div>
 
                         <div class="candidate-score">
-                            Score: <?= number_format($score, 2) ?>
-                            <span class="micro-label">(historical)</span>
+                            Score: <?= number_format($score, 2) ?> (historical)
+                            <span class="micro-label">Not current shortlist rank</span>
                             <div>Ratio: <?= $ratio !== null ? number_format($ratio, 3) : '—' ?></div>
                         </div>
                         
@@ -490,33 +546,11 @@ admin_layout_start("Hero Editor");
                             <span class="btn__dot"></span>
                             Use this hero
                         </button>
-
-                        <?php if ($isBestAuto): ?>
-                            <form method="post" class="mt-1">
-                                <input type="hidden"
-                                       name="reject_image"
-                                       value="<?= htmlspecialchars($path) ?>">
-                                <button
-                                    type="submit"
-                                    name="action"
-                                    value="reject_auto"
-                                    class="btn btn-danger"
-                                >
-                                    Reject auto choice
-                                </button>
-                            </form>
-                        <?php endif; ?>
                     </article>
                 <?php endforeach; ?>
             </div>
         <?php endif; ?>
 
-        <div class="hero-card__actions mt-3">
-            <button type="submit" name="action" value="save_override" class="btn btn-primary">
-                <span class="btn__dot"></span>
-                Save override
-            </button>
-        </div>
     </form>
 </div>
 

--- a/admin/hero-manager.php
+++ b/admin/hero-manager.php
@@ -205,6 +205,16 @@ if (!function_exists('sw_recalc_hero_for_item')) {
 $flashMessage = '';
 $flashType = 'info';
 
+if (!empty($_GET['hero_saved'])) {
+    $savedItemId = (int)($_GET['item_id'] ?? 0);
+    if ($savedItemId > 0) {
+        $flashMessage = 'Manual hero saved for item #' . $savedItemId . '.';
+    } else {
+        $flashMessage = 'Manual hero saved.';
+    }
+    $flashType = 'success';
+}
+
 if (!empty($_GET['recalc'])) {
     $id = (int)$_GET['recalc'];
     $res = sw_recalc_hero_for_item($pdo, $id);

--- a/css/admin/hero.css
+++ b/css/admin/hero.css
@@ -892,3 +892,19 @@
 .hero-rationale-report .hero-report-filter-form label { display:flex; flex-direction:column; gap:4px; font-size:.78rem; color:var(--text-muted); }
 .hero-rationale-report .hero-report-filter-form input,
 .hero-rationale-report .hero-report-filter-form select { background:#0b1220; border:1px solid var(--card-border); color:#e2e8ff; border-radius:8px; padding:6px 8px; }
+
+
+.hero-override-form { gap: 14px; }
+.hero-override-summary { border:1px solid rgba(148,163,235,.35); border-radius:12px; padding:12px; background:rgba(15,23,42,.45); }
+.hero-override-summary h2 { margin:0 0 10px; font-size:.95rem; }
+.hero-override-summary__body { display:grid; grid-template-columns:minmax(180px,220px) 1fr; gap:12px; align-items:start; }
+.hero-override-summary__path { font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace; font-size:.74rem; color:#cbd5e1; word-break: break-all; }
+.hero-override-summary__status { font-size:.8rem; color:#93c5fd; margin-top:6px; }
+.hero-override-summary__actions { display:flex; flex-wrap:wrap; gap:8px; margin-top:10px; }
+.card-grid--candidates { grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); align-items: start; }
+.card-grid--candidates .candidate { min-width:0; }
+.card-imagebox { width:100%; max-width:100%; }
+.candidate .hero-slot__label { gap:6px; flex-wrap:wrap; justify-content:flex-start; }
+.candidate .hero-slot__label .hero-badge { text-transform:none; letter-spacing:0; }
+.candidate--selected { border-width:2px; }
+@media (max-width: 719px) { .hero-override-summary__body { grid-template-columns: 1fr; } }

--- a/js/admin/hero.js
+++ b/js/admin/hero.js
@@ -50,19 +50,45 @@ document.addEventListener("DOMContentLoaded", () => {
 
   document.querySelectorAll("[data-select-hero]").forEach(btn => {
     btn.addEventListener("click", () => {
-
       const imagePath = btn.getAttribute("data-select-hero");
       const input = document.querySelector("#overrideImageInput");
-      if (!input) return;
+      if (!input || !imagePath) return;
 
-      // write input for form submission
       input.value = imagePath;
 
-      // highlight selection
-      document.querySelectorAll(".candidate--selected")
-        .forEach(el => el.classList.remove("candidate--selected"));
+      document.querySelectorAll("[data-candidate-card]").forEach(card => {
+        card.classList.remove("candidate--selected");
+      });
 
-      btn.closest(".candidate").classList.add("candidate--selected");
+      const card = btn.closest("[data-candidate-card]");
+      if (card) card.classList.add("candidate--selected");
+
+      const summaryPath = document.querySelector("[data-override-path]");
+      const summaryStatus = document.querySelector("[data-override-status]");
+      const previewWrap = document.querySelector("[data-override-preview-wrap]");
+      const saveBtn = document.querySelector("[data-save-override]");
+
+      if (summaryPath) summaryPath.textContent = imagePath;
+      if (summaryStatus) summaryStatus.textContent = "Ready to save";
+      if (saveBtn) saveBtn.disabled = false;
+
+      if (previewWrap) {
+        const currentImg = previewWrap.querySelector("img");
+        const base = String(window.BASE_URL || "").replace(/\/+$/, "");
+        const normalizedPath = imagePath.replace(/^\/+/, "");
+        const imageSrc = `${base}/${normalizedPath}`;
+
+        if (currentImg) {
+          currentImg.src = imageSrc;
+        } else {
+          const empty = previewWrap.querySelector("[data-override-preview-empty]");
+          if (empty) empty.remove();
+          const img = document.createElement("img");
+          img.src = imageSrc;
+          img.alt = "Staged override candidate";
+          previewWrap.appendChild(img);
+        }
+      }
     });
   });
 
@@ -266,6 +292,7 @@ document.addEventListener("DOMContentLoaded", () => {
           const profile = product.active_criteria_profile || "—";
           const basis = product.shortlist_basis || "legacy_rank_placeholder";
           const challengeEndpoint = resolveChallengeUrl(product.challenge_endpoint, itemId);
+          const reviewHref = `${baseUrl}/admin/hero-edit.php?id=${encodeURIComponent(itemId)}`;
 
           clearNode(node);
 
@@ -289,7 +316,7 @@ document.addEventListener("DOMContentLoaded", () => {
             foot.appendChild(makeEl("span", "hero-shortlist-preview__pill", `Basis: ${safeText(basis)}`));
 
             const review = makeEl("a", "hero-shortlist-preview__action", "Review candidates");
-            review.href = challengeEndpoint;
+            review.href = reviewHref;
             foot.appendChild(review);
 
             return foot;


### PR DESCRIPTION
### Motivation

- Provide a way to stage a candidate hero image selection before committing it as a manual override, improving editor UX.
- Surface a clear preview and status for the staged candidate and centralize the save/reject controls.
- Give immediate feedback in the manager after a manual save by redirecting and showing a success flash.

### Description

- Added handling of a `select` query parameter and validation to allow staging a candidate via URL in `admin/hero-edit.php` and surface a flash message when the requested candidate is missing.
- Introduced an `effectiveOverride` staging variable and rendered a new summary panel showing a preview, path, status, and consolidated actions in `hero-edit.php`, and set the hidden `override_image` input to the staged value.
- Changed the `save_override` POST handling to redirect to `hero-manager.php` with `hero_saved=1&item_id=` instead of setting an on-page flash, and added success flash handling in `admin/hero-manager.php` for that query parameter.
- Updated candidate tiles to include data attributes and badges indicating active/stored hero state, removed per-tile reject forms, and centralized `reject_auto` control into the summary panel.
- Implemented client-side selection logic in `js/admin/hero.js` to update the hidden input, highlight the selected tile, update the staged preview image/path/status, and enable the save button, with guards for missing inputs.
- Added supporting styles for the summary panel and candidate grid in `css/admin/hero.css` and minor layout adjustments to candidate cards.

### Testing

- No automated unit tests were added for this UI change.
- Performed PHP syntax checks on modified files with `php -l` and ran JS linting (`eslint`) on changed scripts; these checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06b0ec390083249644b48cb90eff04)