### PR TITLE
Fix Hero Editor "Use this hero" staging binding

### DIFF
--- a/admin/hero-edit.php
+++ b/admin/hero-edit.php
@@ -487,7 +487,7 @@ admin_layout_start("Hero Editor");
                     <div class="hero-override-summary__path" data-override-path><?= htmlspecialchars($stagedLabel) ?></div>
                     <div class="hero-override-summary__status" data-override-status><?= htmlspecialchars($stagedStatus) ?></div>
                     <div class="hero-override-summary__actions">
-                        <button type="submit" name="action" value="save_override" class="btn btn-primary" data-save-override>
+                        <button type="submit" name="action" value="save_override" class="btn btn-primary" data-save-override<?= $effectiveOverride === "" ? " disabled" : "" ?>>
                             <span class="btn__dot"></span>
                             Save override
                         </button>
@@ -555,7 +555,10 @@ admin_layout_start("Hero Editor");
 </div>
 
 <!-- Hero JS: fullscreen viewer + candidate selection -->
-<script src="/js/admin/hero.js"></script>
+<script>
+  window.BASE_URL = "<?= BASE_URL ?>";
+</script>
+<script src="<?= BASE_URL ?>/js/admin/hero.js"></script>
 
 <?php
 admin_layout_end();

--- a/js/admin/hero.js
+++ b/js/admin/hero.js
@@ -48,49 +48,72 @@ document.addEventListener("DOMContentLoaded", () => {
      2. Hero Selection (only used in hero-edit.php)
      ------------------------------------------------------------ */
 
-  document.querySelectorAll("[data-select-hero]").forEach(btn => {
-    btn.addEventListener("click", () => {
-      const imagePath = btn.getAttribute("data-select-hero");
-      const input = document.querySelector("#overrideImageInput");
-      if (!input || !imagePath) return;
+  const heroOverrideForm = document.querySelector("#heroOverrideForm");
+  const overrideInput = document.querySelector("#overrideImageInput");
+  const selectHeroButtons = document.querySelectorAll("[data-select-hero]");
 
-      input.value = imagePath;
+  if (heroOverrideForm && overrideInput && selectHeroButtons.length > 0) {
+    const summaryPath = document.querySelector("[data-override-path]");
+    const summaryStatus = document.querySelector("[data-override-status]");
+    const previewWrap = document.querySelector("[data-override-preview-wrap]");
+    const saveBtn = document.querySelector("[data-save-override]");
+
+    const setSaveEnabled = enabled => {
+      if (saveBtn) {
+        saveBtn.disabled = !enabled;
+      }
+    };
+
+    const setStagedState = (imagePath, sourceCard) => {
+      overrideInput.value = imagePath;
 
       document.querySelectorAll("[data-candidate-card]").forEach(card => {
         card.classList.remove("candidate--selected");
       });
 
-      const card = btn.closest("[data-candidate-card]");
-      if (card) card.classList.add("candidate--selected");
-
-      const summaryPath = document.querySelector("[data-override-path]");
-      const summaryStatus = document.querySelector("[data-override-status]");
-      const previewWrap = document.querySelector("[data-override-preview-wrap]");
-      const saveBtn = document.querySelector("[data-save-override]");
+      if (sourceCard) {
+        sourceCard.classList.add("candidate--selected");
+      }
 
       if (summaryPath) summaryPath.textContent = imagePath;
       if (summaryStatus) summaryStatus.textContent = "Ready to save";
-      if (saveBtn) saveBtn.disabled = false;
+      setSaveEnabled(true);
 
-      if (previewWrap) {
-        const currentImg = previewWrap.querySelector("img");
-        const base = String(window.BASE_URL || "").replace(/\/+$/, "");
-        const normalizedPath = imagePath.replace(/^\/+/, "");
-        const imageSrc = `${base}/${normalizedPath}`;
+      if (!previewWrap) return;
 
-        if (currentImg) {
-          currentImg.src = imageSrc;
-        } else {
-          const empty = previewWrap.querySelector("[data-override-preview-empty]");
-          if (empty) empty.remove();
-          const img = document.createElement("img");
-          img.src = imageSrc;
-          img.alt = "Staged override candidate";
-          previewWrap.appendChild(img);
-        }
+      const selectedImg = sourceCard ? sourceCard.querySelector("img") : null;
+      const selectedSrc = selectedImg ? selectedImg.getAttribute("src") : "";
+
+      if (!selectedSrc) return;
+
+      let stagedImg = previewWrap.querySelector("img");
+      if (!stagedImg) {
+        const empty = previewWrap.querySelector("[data-override-preview-empty]");
+        if (empty) empty.remove();
+
+        stagedImg = document.createElement("img");
+        previewWrap.appendChild(stagedImg);
       }
+
+      stagedImg.src = selectedSrc;
+      stagedImg.alt = "Staged override candidate";
+    };
+
+    const hasInitialOverride = overrideInput.value.trim() !== "";
+    setSaveEnabled(hasInitialOverride);
+
+    selectHeroButtons.forEach(btn => {
+      btn.addEventListener("click", event => {
+        event.preventDefault();
+
+        const imagePath = String(btn.getAttribute("data-select-hero") || "").trim();
+        if (!imagePath) return;
+
+        const card = btn.closest("[data-candidate-card]");
+        setStagedState(imagePath, card);
+      });
     });
-  });
+  }
 
   /* ------------------------------------------------------------
      3. Candidate Images Panel (hero-manager.php)


### PR DESCRIPTION
### Motivation
- The Hero Editor’s “Use this hero” buttons were not staging a candidate because the admin script either wasn’t being loaded correctly in subpath deployments and the selection wiring ran without safe page guards.
- Users need an immediate, client-side staging experience that updates the hidden `override_image`, preview, staging highlight and enables `Save override` without a page reload.

### Description
- Ensure `window.BASE_URL` is set and `js/admin/hero.js` is loaded via `<?= BASE_URL ?>` in `admin/hero-edit.php` so the script resolves correctly in subpath deployments.
- Render the `Save override` button disabled when no staged override exists by default using the existing `<?= $effectiveOverride ?>` state in `admin/hero-edit.php`.
- Add scoped guards and refactor selection wiring in `js/admin/hero.js` so the editor-only code runs only when `#heroOverrideForm`, `#overrideImageInput`, and `[data-select-hero]` exist.
- Implement `setStagedState` in `js/admin/hero.js` to update the hidden `override_image`, toggle `.candidate--selected` on cards, update summary `data-override-path`/`data-override-status`, enable `data-save-override`, and update the staged preview by reusing the clicked card’s image `src` (DOM-safe updates, no raw HTML injection).

### Testing
- Ran `php -l admin/hero-edit.php` and it reported no syntax errors (success).
- Ran `node --check js/admin/hero.js` and it reported no issues (success).
- Ran `git diff --check` and it reported no whitespace/patch problems (success).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06c67522e88324a831276c630c567d)