### PR TITLE
Stage 3AR: Fix current hero rank detection and remove misleading rejected-count badges

### DIFF
--- a/admin/hero-manager.php
+++ b/admin/hero-manager.php
@@ -561,9 +561,6 @@ admin_layout_start("Hero Manager");
                                 <span class="hero-badge hero-badge--override">Override active</span>
                             <?php endif; ?>
 
-                            <?php if ($rejects > 0): ?>
-                                <span class="hero-badge hero-badge--rejections"><?= $rejects ?> rejected</span>
-                            <?php endif; ?>
 
                             <?php if ($autoImg && !admin_image_exists($autoImg)): ?>
                                 <span class="hero-badge hero-badge--missing">Missing (auto)</span>
@@ -638,10 +635,6 @@ admin_layout_start("Hero Manager");
                             <?php endif; ?>
                         </div>
 
-                        <div class="hero-slot__meta">
-                            <span>rejected:</span>
-                            <span><?= $rejects ?></span>
-                        </div>
                     </div>
                 </div>
 

--- a/admin/hero-shortlists.php
+++ b/admin/hero-shortlists.php
@@ -89,6 +89,7 @@ foreach ($items as $item) {
         'shortlist_status' => $shortlist['shortlist_status'] ?? 'unavailable',
         'current_hero' => $shortlist['current_hero'] ?? null,
         'recommended_candidates' => $shortlist['recommended_candidates'] ?? [],
+        'all_candidates' => $shortlist['all_candidates'] ?? [],
         'candidate_count' => is_array($candidates) ? count($candidates) : 0,
         'challenge_endpoint' => 'admin/hero-candidates.php?item_id=' . $itemId . '&include_shortlist=1',
     ];

--- a/js/admin/hero.js
+++ b/js/admin/hero.js
@@ -236,6 +236,66 @@ document.addEventListener("DOMContentLoaded", () => {
       return `${baseUrl}/${cleanPath}`;
     };
 
+    const normalizeComparablePath = value => {
+      const raw = String(value || "").trim();
+      if (!raw) return "";
+
+      let normalized = raw;
+      try {
+        const url = new URL(raw, "https://example.invalid");
+        normalized = `${url.pathname || ""}${url.search || ""}${url.hash || ""}`;
+      } catch (_) {
+        normalized = raw;
+      }
+
+      normalized = normalized
+        .replace(/^[a-z]+:\/\/[^/]+/i, "")
+        .replace(/[#?].*$/, "")
+        .replace(/^\.\//, "")
+        .replace(/\\/g, "/")
+        .replace(/^\/+/, "")
+        .replace(/\/+/g, "/")
+        .trim();
+
+      try {
+        normalized = decodeURIComponent(normalized);
+      } catch (_) {
+        // Keep non-decodable URI fragments unchanged.
+      }
+
+      return normalized;
+    };
+
+    const getHeroRankStatus = (itemId, product) => {
+      const currentHeroNode = document.querySelector(`[data-item-id="${CSS.escape(String(itemId || ""))}"]`);
+      const effectivePath = normalizeComparablePath(currentHeroNode?.dataset?.currentHero || product?.current_hero?.path || "");
+      const topCandidates = Array.isArray(product?.recommended_candidates) ? product.recommended_candidates : [];
+      const allCandidates = Array.isArray(product?.all_candidates) ? product.all_candidates : [];
+
+      if (!effectivePath) {
+        return { message: "Current hero: none", outsideTopThree: false, rank: null };
+      }
+
+      const shortlistIndex = topCandidates.findIndex(c => normalizeComparablePath(c?.path || "") === effectivePath);
+      if (shortlistIndex >= 0) {
+        const rank = Number(topCandidates[shortlistIndex]?.recommendation_rank || shortlistIndex + 1);
+        return { message: `Current hero is shortlist #${rank}`, outsideTopThree: false, rank };
+      }
+
+      const allIndex = allCandidates.findIndex(c => normalizeComparablePath(c?.path || "") === effectivePath);
+      if (allIndex >= 0) {
+        const rank = Number(allCandidates[allIndex]?.rank || allIndex + 1);
+        return { message: `Current hero outside top 3 · ranked #${rank}`, outsideTopThree: true, rank };
+      }
+
+      const fallbackRank = Number(product?.current_hero?.rank || 0);
+      if (fallbackRank > 0) {
+        return { message: `Current hero outside top 3 · ranked #${fallbackRank}`, outsideTopThree: true, rank: fallbackRank };
+      }
+
+      return { message: "Current hero outside candidate set", outsideTopThree: true, rank: null };
+    };
+
     const resolveChallengeUrl = (endpoint, itemId) => {
       const fallback = `admin/hero-candidates.php?item_id=${encodeURIComponent(itemId)}&include_shortlist=1`;
       const raw = String(endpoint || fallback).trim();
@@ -310,8 +370,13 @@ document.addEventListener("DOMContentLoaded", () => {
             ? product.recommended_candidates.slice(0, 3)
             : [];
 
+          const rankStatus = getHeroRankStatus(itemId, product);
           const currentHero = product.current_hero || null;
-          const outsideTopThree = !!(currentHero && currentHero.current_hero_outside_top_three);
+          product.current_hero = {
+            ...(currentHero || {}),
+            current_hero_outside_top_three: !!rankStatus.outsideTopThree,
+            current_hero_rank: rankStatus.rank
+          };
           const profile = product.active_criteria_profile || "—";
           const basis = product.shortlist_basis || "legacy_rank_placeholder";
           const challengeEndpoint = resolveChallengeUrl(product.challenge_endpoint, itemId);
@@ -376,18 +441,10 @@ document.addEventListener("DOMContentLoaded", () => {
 
           node.appendChild(thumbsWrap);
 
-          const current = makeEl(
-            "div",
-            "hero-shortlist-preview__current",
-            `Current hero: ${currentHero && currentHero.path ? "available" : "none"}`
-          );
+          const current = makeEl("div", "hero-shortlist-preview__current", rankStatus.message);
 
-          if (outsideTopThree) {
-            current.appendChild(makeEl(
-              "span",
-              "hero-shortlist-preview__flag",
-              "Current hero outside shortlist"
-            ));
+          if (rankStatus.outsideTopThree) {
+            current.appendChild(makeEl("span", "hero-shortlist-preview__flag", "Needs review"));
           }
 
           node.appendChild(current);


### PR DESCRIPTION
### Motivation
- The Hero Manager showed misleading status after manual hero selection by using a stale `current_hero_outside_top_three` flag and a numeric "X rejected" badge.
- The UI must report the effective current hero (including manual override) relative to the ranked shortlist/candidates and not surface an ambiguous rejected-count on the product card.
- This change implements a narrow fix that only adjusts display/labeling logic and does not alter scoring, ranking, persistence, rationale, or rejection endpoints.

### Description
- Compute the effective current hero in the shortlist preview by reading the rendered card `data-current-hero` (manual override) or falling back to the `product.current_hero.path`, and compare against candidates using a conservative `normalizeComparablePath` normalization routine. (Changed: `js/admin/hero.js`)
- Add `getHeroRankStatus` to produce rank-aware messages such as `Current hero is shortlist #N`, `Current hero outside top 3 · ranked #N`, or `Current hero outside candidate set`, and mark `outsideTopThree` only when appropriate. (Changed: `js/admin/hero.js`)
- Stop showing the misleading rejected-count displays by removing the `<?= $rejects ?> rejected` badge and the `rejected: N` computed-baseline meta area. (Changed: `admin/hero-manager.php`)
- Expose `all_candidates` in the shortlist API payload so the client can determine the hero's true rank outside the top three without changing ranking/scoring server logic. (Changed: `admin/hero-shortlists.php`)
- Files changed: `js/admin/hero.js`, `admin/hero-manager.php`, `admin/hero-shortlists.php`.

### Testing
- Ran PHP syntax checks: `php -l admin/hero-manager.php` and `php -l admin/hero-shortlists.php`, both reported no syntax errors. ✅
- Ran JS static check: `node --check js/admin/hero.js`, which completed without errors. ✅
- Ran repository whitespace/check: `git diff --check`, which returned no problems. ✅

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06ed85d0ac8324a5a2dea6b3a89f68)