### PR TITLE
Stage 3AU: Add rationale snapshot fields storage migration

### DIFF
--- a/db/migrations/2026-05-16-stage-3au-rationale-snapshot-fields.sql
+++ b/db/migrations/2026-05-16-stage-3au-rationale-snapshot-fields.sql
@@ -1,0 +1,75 @@
+-- Stage 3AU: Rationale snapshot/comparison storage extension
+-- Storage-only migration for future decision-type-first rationale records.
+--
+-- This migration prepares hero_override_rationale to store:
+--   * selected-image snapshot details,
+--   * system-ranked #1 snapshot details,
+--   * optional displaced-current-hero snapshot details,
+--   * criteria/shortlist snapshot context,
+--   * decision-type and comparison-target role,
+--   * product-specific reasons/cross-cutting signals,
+--   * eligibility/data-quality flags,
+--   * optional structured snapshot metadata.
+--
+-- Important:
+--   * No runtime behavior is changed by this migration.
+--   * No existing columns are removed or renamed.
+--   * No existing records are backfilled or rewritten.
+--   * Legacy rationale records remain valid for historical/exploratory review,
+--     but should not be automatically interpreted as clean criteria-refinement
+--     training data.
+
+ALTER TABLE hero_override_rationale
+    -- Product snapshot
+    ADD COLUMN product_name_snapshot VARCHAR(255) DEFAULT NULL AFTER itemId,
+    ADD COLUMN brand_snapshot VARCHAR(100) DEFAULT NULL AFTER product_name_snapshot,
+
+    -- Selected image snapshot
+    ADD COLUMN selected_image_path VARCHAR(1024) DEFAULT NULL AFTER brand_snapshot,
+    ADD COLUMN selected_image_rank_snapshot SMALLINT UNSIGNED DEFAULT NULL AFTER selected_image_path,
+    ADD COLUMN selected_image_score_snapshot DECIMAL(10,4) DEFAULT NULL AFTER selected_image_rank_snapshot,
+    ADD COLUMN selected_image_role VARCHAR(80) DEFAULT NULL AFTER selected_image_score_snapshot,
+
+    -- System-ranked #1 snapshot
+    ADD COLUMN ranked_1_image_path_snapshot VARCHAR(1024) DEFAULT NULL AFTER selected_image_role,
+    ADD COLUMN ranked_1_image_score_snapshot DECIMAL(10,4) DEFAULT NULL AFTER ranked_1_image_path_snapshot,
+    ADD COLUMN ranked_1_image_role VARCHAR(80) DEFAULT NULL AFTER ranked_1_image_score_snapshot,
+    ADD COLUMN ranked_1_reason_snapshot TEXT DEFAULT NULL AFTER ranked_1_image_role,
+
+    -- Displaced current hero snapshot
+    ADD COLUMN displaced_current_hero_path_snapshot VARCHAR(1024) DEFAULT NULL AFTER ranked_1_reason_snapshot,
+    ADD COLUMN displaced_current_hero_rank_snapshot SMALLINT UNSIGNED DEFAULT NULL AFTER displaced_current_hero_path_snapshot,
+    ADD COLUMN displaced_current_hero_role VARCHAR(80) DEFAULT NULL AFTER displaced_current_hero_rank_snapshot,
+
+    -- Criteria/shortlist snapshot
+    ADD COLUMN criteria_profile_snapshot VARCHAR(128) DEFAULT NULL AFTER displaced_current_hero_role,
+    ADD COLUMN shortlist_basis_snapshot VARCHAR(128) DEFAULT NULL AFTER criteria_profile_snapshot,
+
+    -- Decision model snapshot
+    ADD COLUMN decision_type VARCHAR(80) DEFAULT NULL AFTER shortlist_basis_snapshot,
+    ADD COLUMN comparison_target_role VARCHAR(80) DEFAULT NULL AFTER decision_type,
+
+    -- Future reason/signal storage (LONGTEXT by convention; no JSON type dependency)
+    ADD COLUMN product_specific_reason_codes LONGTEXT DEFAULT NULL AFTER comparison_target_role,
+    ADD COLUMN cross_cutting_signal_codes LONGTEXT DEFAULT NULL AFTER product_specific_reason_codes,
+    ADD COLUMN reviewer_note TEXT DEFAULT NULL AFTER cross_cutting_signal_codes,
+
+    -- Eligibility flags
+    ADD COLUMN counts_toward_criteria_refinement TINYINT(1) NOT NULL DEFAULT 0 AFTER reviewer_note,
+    ADD COLUMN data_quality_only TINYINT(1) NOT NULL DEFAULT 0 AFTER counts_toward_criteria_refinement,
+
+    -- Optional structured snapshots (stored as LONGTEXT for compatibility)
+    ADD COLUMN candidate_snapshot_json LONGTEXT DEFAULT NULL AFTER data_quality_only,
+    ADD COLUMN reviewer_metadata_json LONGTEXT DEFAULT NULL AFTER candidate_snapshot_json,
+
+    -- Reporting-oriented indexes for future rationale analysis
+    ADD KEY idx_hor_decision_type (decision_type),
+    ADD KEY idx_hor_comparison_target_role (comparison_target_role),
+    ADD KEY idx_hor_criteria_profile_snapshot (criteria_profile_snapshot),
+    ADD KEY idx_hor_counts_toward_criteria_refinement (counts_toward_criteria_refinement),
+    ADD KEY idx_hor_data_quality_only (data_quality_only),
+    ADD KEY idx_hor_selected_image_rank_snapshot (selected_image_rank_snapshot),
+    ADD KEY idx_hor_displaced_current_hero_rank_snapshot (displaced_current_hero_rank_snapshot),
+    ADD KEY idx_hor_item_decision_type (itemId, decision_type),
+    ADD KEY idx_hor_decision_type_counts_refinement (decision_type, counts_toward_criteria_refinement),
+    ADD KEY idx_hor_data_quality_decision_type (data_quality_only, decision_type);


### PR DESCRIPTION
### Motivation
- Prepare the existing `hero_override_rationale` table for a future decision-type-first rationale model by adding nullable snapshot and comparison storage fields to capture selected images, the system-ranked #1 at decision time, displaced heroes, criteria/shortlist context, decision metadata, and reason/signal payloads. 
- Keep this change strictly storage-only so no runtime behavior, UI, API, scoring/ranking, or reporting code is changed and existing records remain valid without backfill.

### Description
- Add a new SQL migration file at `db/migrations/2026-05-16-stage-3au-rationale-snapshot-fields.sql` which alters `hero_override_rationale` to add product snapshot, selected-image snapshot, ranked-#1 snapshot, displaced-hero snapshot, criteria/shortlist snapshot, decision-model fields, LONGTEXT reason/signal payloads, eligibility flags, and optional structured snapshot LONGTEXT fields. 
- Use `LONGTEXT` for JSON-like payloads (no MySQL `JSON` type) for `product_specific_reason_codes`, `cross_cutting_signal_codes`, `candidate_snapshot_json`, and `reviewer_metadata_json` to match existing project conventions. 
- Add reporting-oriented indexes (single-column and a few small compound indexes) for `decision_type`, `comparison_target_role`, `criteria_profile_snapshot`, eligibility flags, and rank snapshot fields while avoiding full indexing of long path columns. 
- Include clear SQL comments stating this is Stage 3AU, storage-only, does not backfill or rename/remove legacy columns, and that legacy records remain exploratory.

### Testing
- Ran `rg --files -g 'AGENTS.md'` to look for agent-specific PR instructions and found no matching files. 
- Confirmed current migration listing includes the existing Stage 3AD migration (`2026-05-14-stage-3ad-hero-override-rationale.sql`) prior to adding the new file. 
- Created the new migration file and inspected it with a line-numbered print (`nl -ba db/migrations/2026-05-16-stage-3au-rationale-snapshot-fields.sql`) to verify the added columns, defaults, comments, and indexes match the requirements. 
- Performed repository consistency and diff checks to ensure only the new migration file was introduced and recorded PR metadata via the `make_pr` flow; automated checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07a93b3f908324b0da4aefc7aa187c)