### PR TITLE
Refresh rationale status badge when shortlist data arrives

### DIFF
--- a/js/admin/hero.js
+++ b/js/admin/hero.js
@@ -377,6 +377,11 @@ document.addEventListener("DOMContentLoaded", () => {
             current_hero_outside_top_three: !!rankStatus.outsideTopThree,
             current_hero_rank: rankStatus.rank
           };
+
+          const rationaleNode = document.querySelector(`[data-rationale-item-id="${CSS.escape(itemId)}"]`);
+          if (rationaleNode && typeof applyStatusFromState === "function") {
+            applyStatusFromState(rationaleNode);
+          }
           const profile = product.active_criteria_profile || "—";
           const basis = product.shortlist_basis || "legacy_rank_placeholder";
           const challengeEndpoint = resolveChallengeUrl(product.challenge_endpoint, itemId);


### PR DESCRIPTION
### Motivation
- Shortlist data was being loaded after the rationale badges were evaluated, so badges could show "No rationale saved" even when the shortlist panel indicated "Current hero is shortlist #1"; the change ensures the badge is re-evaluated once shortlist info (rank/inside-top-three) is available.

### Description
- In `js/admin/hero.js` call `applyStatusFromState()` for the matching `[data-rationale-item-id]` node immediately after `shortlistByItem.set(itemId, product || null)` and after populating `product.current_hero.current_hero_outside_top_three` and `product.current_hero_rank`, so the rationale badge updates without opening/saving the rationale panel.

### Testing
- Ran `node --check js/admin/hero.js` and it succeeded.  
- Ran `git diff --check` and it reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08047e56b883249e9dd941f0bab060)