### PR TITLE
Fix shortlist preview failure by sharing path normalizer scope

### DIFF
--- a/js/admin/hero.js
+++ b/js/admin/hero.js
@@ -9,6 +9,35 @@
 document.addEventListener("DOMContentLoaded", () => {
   const baseUrl = String(window.BASE_URL || "").replace(/\/+$/, "");
   const shortlistByItem = new Map();
+  const normalizeComparablePath = value => {
+    const raw = String(value || "").trim();
+    if (!raw) return "";
+
+    let normalized = raw;
+    try {
+      const url = new URL(raw, "https://example.invalid");
+      normalized = `${url.pathname || ""}${url.search || ""}${url.hash || ""}`;
+    } catch (_) {
+      normalized = raw;
+    }
+
+    normalized = normalized
+      .replace(/^[a-z]+:\/\/[^/]+/i, "")
+      .replace(/[#?].*$/, "")
+      .replace(/^\.\//, "")
+      .replace(/\\/g, "/")
+      .replace(/^\/+/, "")
+      .replace(/\/+/g, "/")
+      .trim();
+
+    try {
+      normalized = decodeURIComponent(normalized);
+    } catch (_) {
+      // Keep non-decodable URI fragments unchanged.
+    }
+
+    return normalized;
+  };
 
   /* ------------------------------------------------------------
      1. PhotoSwipe Fullscreen Viewer
@@ -234,36 +263,6 @@ document.addEventListener("DOMContentLoaded", () => {
       const cleanPath = String(path || "").replace(/^\/+/, "");
 
       return `${baseUrl}/${cleanPath}`;
-    };
-
-    const normalizeComparablePath = value => {
-      const raw = String(value || "").trim();
-      if (!raw) return "";
-
-      let normalized = raw;
-      try {
-        const url = new URL(raw, "https://example.invalid");
-        normalized = `${url.pathname || ""}${url.search || ""}${url.hash || ""}`;
-      } catch (_) {
-        normalized = raw;
-      }
-
-      normalized = normalized
-        .replace(/^[a-z]+:\/\/[^/]+/i, "")
-        .replace(/[#?].*$/, "")
-        .replace(/^\.\//, "")
-        .replace(/\\/g, "/")
-        .replace(/^\/+/, "")
-        .replace(/\/+/g, "/")
-        .trim();
-
-      try {
-        normalized = decodeURIComponent(normalized);
-      } catch (_) {
-        // Keep non-decodable URI fragments unchanged.
-      }
-
-      return normalized;
     };
 
     const getHeroRankStatus = (itemId, product) => {


### PR DESCRIPTION
### Motivation
- Shortlist preview could surface "Endpoint error / unable to load shortlist" because rationale refresh calls `buildSnapshotContext()` -> `normalizePath()` -> `normalizeComparablePath()` while `normalizeComparablePath` was defined inside a shortlist-only block, leading to a `ReferenceError` when invoked from the rationale path. 
- The intent is to make the robust path-normalization helper available to both the shortlist preview and rationale/status code paths so the shortlist preview loads and the rationale badge updates reliably.

### Description
- Move `normalizeComparablePath` into the shared `DOMContentLoaded` scope so it is available to both shortlist preview rendering and rationale/snapshot helpers. 
- Remove the duplicate block-scoped `normalizeComparablePath` definition from inside the shortlist preview block. 
- Preserve all existing ranking, scoring, and rationale behavior; this is a small JS-only scope/order fix and does not modify data models or auto-save behavior.

### Testing
- Ran `node --check js/admin/hero.js` and it completed with no syntax errors. 
- Ran `git diff --check` and it reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08205b6a508324be28ba706c04749b)