### PR TITLE
Clean up Hero Manager shortlist preview metadata and action label

### DIFF
--- a/js/admin/hero.js
+++ b/js/admin/hero.js
@@ -381,8 +381,6 @@ document.addEventListener("DOMContentLoaded", () => {
           if (rationaleNode && typeof applyStatusFromState === "function") {
             applyStatusFromState(rationaleNode);
           }
-          const profile = product.active_criteria_profile || "—";
-          const basis = product.shortlist_basis || "legacy_rank_placeholder";
           const challengeEndpoint = resolveChallengeUrl(product.challenge_endpoint, itemId);
           const reviewHref = `${baseUrl}/admin/hero-edit.php?id=${encodeURIComponent(itemId)}`;
 
@@ -403,11 +401,7 @@ document.addEventListener("DOMContentLoaded", () => {
 
           const makeShortlistFoot = () => {
             const foot = makeEl("div", "hero-shortlist-preview__foot");
-
-            foot.appendChild(makeEl("span", "hero-shortlist-preview__pill", `Profile: ${safeText(profile)}`));
-            foot.appendChild(makeEl("span", "hero-shortlist-preview__pill", `Basis: ${safeText(basis)}`));
-
-            const review = makeEl("a", "hero-shortlist-preview__action", "Review candidates");
+            const review = makeEl("a", "hero-shortlist-preview__action", "Review / change hero");
             review.href = reviewHref;
             foot.appendChild(review);
 
@@ -446,10 +440,6 @@ document.addEventListener("DOMContentLoaded", () => {
           node.appendChild(thumbsWrap);
 
           const current = makeEl("div", "hero-shortlist-preview__current", rankStatus.message);
-
-          if (rankStatus.outsideTopThree) {
-            current.appendChild(makeEl("span", "hero-shortlist-preview__flag", "Needs review"));
-          }
 
           node.appendChild(current);
           node.appendChild(makeShortlistFoot());


### PR DESCRIPTION
### Motivation
- Reduce low-value diagnostic clutter in the Hero Manager shortlist preview so the card focuses on editorial state and top candidates.
- Keep underlying shortlist/profile/basis data for deeper workflows while removing these items from the normal preview UI.
- Clarify the intent of the shortlist action by making the button label explicit about reviewing or changing the hero.

### Description
- Removed rendering of the visible `Profile: …` and `Basis: …` pills from the shortlist preview footer while leaving the underlying `product` fields intact (changed in `js/admin/hero.js`).
- Removed the visible `Needs review` flag pill that was appended to the current-hero line for outside-top-three cases so the primary `rankStatus.message` remains the visible state.
- Renamed the shortlist action link text from `Review candidates` to `Review / change hero` and preserved the existing `href` to `admin/hero-edit.php`.
- Made no changes to ranking/scoring, database schema, rationale saving, snapshot payloads, automatic hero selection, or deeper Hero Editor behavior.

### Testing
- Ran `node --check js/admin/hero.js` and the check succeeded.
- Ran `git diff --check` and no issues were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0826a13994832491c616abd171a948)