### PR TITLE
Add shortlist diagnostics to Hero Editor review page

### DIFF
--- a/admin/hero-edit.php
+++ b/admin/hero-edit.php
@@ -365,6 +365,24 @@ if ($heroOrient === 'L') {
 $bestPathForReject = $bestCandidate ? $bestCandidate['path'] : '';
 $stagedLabel = $effectiveOverride !== '' ? $effectiveOverride : 'No candidate selected';
 $stagedStatus = $effectiveOverride !== '' ? 'Ready to save' : 'Select a candidate, then save override';
+$activeHeroRankText = 'Unavailable';
+$activeCriteriaProfileText = '';
+$rankingBasisText = '';
+$heroContextParts = [];
+
+if ($activeHero !== '') {
+    $heroContextParts[] = 'Current hero in use';
+}
+if ($heroImage !== '') {
+    $heroContextParts[] = 'Stored hero image available';
+}
+if ($override !== '') {
+    $heroContextParts[] = 'Manual override currently saved';
+}
+if ($selectedFromQueryValid) {
+    $heroContextParts[] = 'Review selection staged (not yet saved)';
+}
+$heroContextText = !empty($heroContextParts) ? implode(' · ', $heroContextParts) : '';
 // --------------------------------------------------------
 // 6) Render layout
 // --------------------------------------------------------
@@ -390,6 +408,18 @@ admin_layout_start("Hero Editor");
             <span><?= $flashMessage ?></span>
         </div>
     <?php endif; ?>
+
+    <section class="card mb-3" data-shortlist-diagnostics data-item-id="<?= $itemId ?>">
+        <h2 style="font-size:1.0rem;margin:0 0 8px;">Shortlist diagnostics</h2>
+        <div class="hero-slot__meta">
+            <span data-diagnostic-rank>Current hero rank: <?= htmlspecialchars($activeHeroRankText) ?></span>
+            <?php if ($heroContextText !== ''): ?>
+                <span data-diagnostic-context><?= htmlspecialchars($heroContextText) ?></span>
+            <?php endif; ?>
+            <span data-diagnostic-profile hidden>Criteria profile: <?= htmlspecialchars($activeCriteriaProfileText) ?></span>
+            <span data-diagnostic-basis hidden>Ranking basis: <?= htmlspecialchars($rankingBasisText) ?></span>
+        </div>
+    </section>
 
     <!-- Current hero / override summary -->
     <section class="card mb-3">
@@ -562,4 +592,3 @@ admin_layout_start("Hero Editor");
 
 <?php
 admin_layout_end();
-

--- a/js/admin/hero.js
+++ b/js/admin/hero.js
@@ -38,6 +38,24 @@ document.addEventListener("DOMContentLoaded", () => {
 
     return normalized;
   };
+  const humanizeCriteriaProfile = profile => {
+    const normalized = String(profile || "").trim();
+    const labels = {
+      object_only: "Object-focused",
+      body_region_first: "Body-region first",
+      product_first: "Product-first",
+      full_outfit: "Full outfit"
+    };
+
+    return labels[normalized] || normalized || "";
+  };
+  const humanizeRankingBasis = basis => {
+    const normalized = String(basis || "").trim();
+    if (normalized === "legacy_rank_placeholder") {
+      return "temporary legacy ranking";
+    }
+    return normalized;
+  };
 
   /* ------------------------------------------------------------
      1. PhotoSwipe Fullscreen Viewer
@@ -142,6 +160,72 @@ document.addEventListener("DOMContentLoaded", () => {
         setStagedState(imagePath, card);
       });
     });
+  }
+
+  const diagnosticsNode = document.querySelector("[data-shortlist-diagnostics]");
+  if (diagnosticsNode) {
+    const itemId = String(diagnosticsNode.dataset.itemId || "").trim();
+    const rankNode = diagnosticsNode.querySelector("[data-diagnostic-rank]");
+    const contextNode = diagnosticsNode.querySelector("[data-diagnostic-context]");
+    const profileNode = diagnosticsNode.querySelector("[data-diagnostic-profile]");
+    const basisNode = diagnosticsNode.querySelector("[data-diagnostic-basis]");
+
+    if (itemId && rankNode) {
+      const currentActiveHeroPath = normalizeComparablePath(
+        document.querySelector('[data-candidate-card][data-is-active-hero="1"]')?.dataset?.candidatePath || ""
+      );
+
+      fetch(`${baseUrl}/admin/hero-candidates.php?item_id=${encodeURIComponent(itemId)}&include_shortlist=1`)
+        .then(res => res.ok ? res.json() : Promise.reject(new Error("diagnostics_endpoint")))
+        .then(shortlist => {
+          const recommended = Array.isArray(shortlist?.recommended_candidates) ? shortlist.recommended_candidates : [];
+          const allCandidates = Array.isArray(shortlist?.all_candidates) ? shortlist.all_candidates : [];
+          const effectiveHeroPath = normalizeComparablePath(currentActiveHeroPath || shortlist?.current_hero?.path || "");
+          let heroRankText = "Current hero rank: outside candidate set";
+
+          if (!effectiveHeroPath) {
+            heroRankText = "Current hero rank: none selected";
+          } else {
+            const shortlistIndex = recommended.findIndex(c => normalizeComparablePath(c?.path || "") === effectiveHeroPath);
+            if (shortlistIndex >= 0) {
+              const rank = Number(recommended[shortlistIndex]?.recommendation_rank || shortlistIndex + 1);
+              heroRankText = `Current hero rank: #${rank}`;
+            } else {
+              const allIndex = allCandidates.findIndex(c => normalizeComparablePath(c?.path || "") === effectiveHeroPath);
+              const fallbackRank = Number(shortlist?.current_hero?.rank || 0);
+              const rank = allIndex >= 0 ? Number(allCandidates[allIndex]?.rank || allIndex + 1) : fallbackRank;
+              if (rank > 0) {
+                heroRankText = `Current hero rank: outside top 3 · ranked #${rank}`;
+              }
+            }
+          }
+
+          rankNode.textContent = heroRankText;
+
+          if (contextNode) {
+            const contextParts = [];
+            if (effectiveHeroPath) contextParts.push("Current hero in use");
+            if (shortlist?.current_hero?.is_manual_override) contextParts.push("Manual override saved");
+            if (shortlist?.current_hero?.is_in_recommended_candidates) contextParts.push("Included in current top 3");
+            contextNode.textContent = contextParts.length > 0 ? contextParts.join(" · ") : "No active hero context found";
+          }
+
+          const profileLabel = humanizeCriteriaProfile(shortlist?.active_criteria_profile || "");
+          if (profileNode && profileLabel) {
+            profileNode.hidden = false;
+            profileNode.textContent = `Criteria profile: ${profileLabel}`;
+          }
+
+          const basisLabel = humanizeRankingBasis(shortlist?.shortlist_basis || "");
+          if (basisNode && basisLabel) {
+            basisNode.hidden = false;
+            basisNode.textContent = `Ranking basis: ${basisLabel}`;
+          }
+        })
+        .catch(() => {
+          rankNode.textContent = "Current hero rank: unavailable";
+        });
+    }
   }
 
   /* ------------------------------------------------------------


### PR DESCRIPTION
### Motivation
- Surface shortlist/ranking metadata in the deeper Hero Editor review workflow without reintroducing developer-facing fields into the normal Hero Manager card.
- Keep the change read-only and non-invasive so no ranking, saving, rationale, or schema behavior is altered.

### Description
- Added a compact "Shortlist diagnostics" panel to `admin/hero-edit.php` that renders safe server-side fallback text and placeholders for rank, context, criteria profile, and ranking basis.
- Added a small Hero Editor-only JS loader in `js/admin/hero.js` that fetches existing shortlist contract data from `admin/hero-candidates.php?include_shortlist=1` and updates the diagnostics panel asynchronously.
- Converted internal values into editor-friendly labels in JS (e.g., criteria profile codes → human-readable labels, `legacy_rank_placeholder` → "temporary legacy ranking").
- Changes are UI/read-only only and limited to `admin/hero-edit.php` and `js/admin/hero.js`; no scoring, DB schema, rationale-saving, or hero-manager preview changes were made.

### Testing
- Ran `php -l admin/hero-edit.php` with no syntax errors detected (success).
- Ran `node --check js/admin/hero.js` with no JS syntax errors detected (success).
- Ran `git diff --check` and staging/commit validations; no issues reported (success).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08456220308324b40b7054d554f2aa)