### PR TITLE
Compact Hero Editor shortlist diagnostics layout

### DIFF
--- a/admin/hero-edit.php
+++ b/admin/hero-edit.php
@@ -409,16 +409,23 @@ admin_layout_start("Hero Editor");
         </div>
     <?php endif; ?>
 
-    <section class="card mb-3" data-shortlist-diagnostics data-item-id="<?= $itemId ?>">
+    <section class="card mb-3 hero-diagnostics" data-shortlist-diagnostics data-item-id="<?= $itemId ?>">
         <h2 style="font-size:1.0rem;margin:0 0 8px;">Shortlist diagnostics</h2>
-        <div class="hero-slot__meta">
-            <span data-diagnostic-rank>Current hero rank: <?= htmlspecialchars($activeHeroRankText) ?></span>
-            <?php if ($heroContextText !== ''): ?>
-                <span data-diagnostic-context><?= htmlspecialchars($heroContextText) ?></span>
-            <?php endif; ?>
-            <span data-diagnostic-profile hidden>Criteria profile: <?= htmlspecialchars($activeCriteriaProfileText) ?></span>
-            <span data-diagnostic-basis hidden>Ranking basis: <?= htmlspecialchars($rankingBasisText) ?></span>
+        <div class="hero-diagnostics__grid">
+            <div class="hero-diagnostics__item">
+                <div class="hero-diagnostics__label">Current hero rank</div>
+                <div class="hero-diagnostics__value" data-diagnostic-rank><?= htmlspecialchars($activeHeroRankText) ?></div>
+            </div>
+            <div class="hero-diagnostics__item">
+                <div class="hero-diagnostics__label">Hero context</div>
+                <div class="hero-diagnostics__value" data-diagnostic-context><?= htmlspecialchars($heroContextText !== '' ? $heroContextText : '—') ?></div>
+            </div>
+            <div class="hero-diagnostics__item">
+                <div class="hero-diagnostics__label">Ranking basis</div>
+                <div class="hero-diagnostics__value" data-diagnostic-basis><?= htmlspecialchars($rankingBasisText) ?></div>
+            </div>
         </div>
+        <div class="hero-diagnostics__hidden" hidden data-diagnostic-profile><?= htmlspecialchars($activeCriteriaProfileText) ?></div>
     </section>
 
     <!-- Current hero / override summary -->

--- a/css/admin/hero.css
+++ b/css/admin/hero.css
@@ -237,6 +237,40 @@
     gap: 6px;
 }
 
+.hero-diagnostics {
+    max-width: 760px;
+}
+
+.hero-diagnostics__grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    gap: 10px;
+}
+
+.hero-diagnostics__item {
+    border: 1px solid var(--line, rgba(148, 163, 184, 0.3));
+    border-radius: 8px;
+    padding: 10px 12px;
+    background: rgba(15, 23, 42, 0.04);
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 4px;
+}
+
+.hero-diagnostics__label {
+    font-size: 0.72rem;
+    color: var(--text-muted);
+}
+
+.hero-diagnostics__value {
+    font-size: 0.86rem;
+    color: var(--text);
+    line-height: 1.35;
+    text-align: left;
+    word-break: break-word;
+}
+
 
 /* =========================================================
    hero-manager — action buttons

--- a/js/admin/hero.js
+++ b/js/admin/hero.js
@@ -181,21 +181,21 @@ document.addEventListener("DOMContentLoaded", () => {
           const recommended = Array.isArray(shortlist?.recommended_candidates) ? shortlist.recommended_candidates : [];
           const allCandidates = Array.isArray(shortlist?.all_candidates) ? shortlist.all_candidates : [];
           const effectiveHeroPath = normalizeComparablePath(currentActiveHeroPath || shortlist?.current_hero?.path || "");
-          let heroRankText = "Current hero rank: outside candidate set";
+          let heroRankText = "outside candidate set";
 
           if (!effectiveHeroPath) {
-            heroRankText = "Current hero rank: none selected";
+            heroRankText = "none selected";
           } else {
             const shortlistIndex = recommended.findIndex(c => normalizeComparablePath(c?.path || "") === effectiveHeroPath);
             if (shortlistIndex >= 0) {
               const rank = Number(recommended[shortlistIndex]?.recommendation_rank || shortlistIndex + 1);
-              heroRankText = `Current hero rank: #${rank}`;
+              heroRankText = `#${rank}`;
             } else {
               const allIndex = allCandidates.findIndex(c => normalizeComparablePath(c?.path || "") === effectiveHeroPath);
               const fallbackRank = Number(shortlist?.current_hero?.rank || 0);
               const rank = allIndex >= 0 ? Number(allCandidates[allIndex]?.rank || allIndex + 1) : fallbackRank;
               if (rank > 0) {
-                heroRankText = `Current hero rank: outside top 3 · ranked #${rank}`;
+                heroRankText = `outside top 3 · ranked #${rank}`;
               }
             }
           }
@@ -213,17 +213,17 @@ document.addEventListener("DOMContentLoaded", () => {
           const profileLabel = humanizeCriteriaProfile(shortlist?.active_criteria_profile || "");
           if (profileNode && profileLabel) {
             profileNode.hidden = false;
-            profileNode.textContent = `Criteria profile: ${profileLabel}`;
+            profileNode.textContent = profileLabel;
           }
 
           const basisLabel = humanizeRankingBasis(shortlist?.shortlist_basis || "");
           if (basisNode && basisLabel) {
             basisNode.hidden = false;
-            basisNode.textContent = `Ranking basis: ${basisLabel}`;
+            basisNode.textContent = basisLabel;
           }
         })
         .catch(() => {
-          rankNode.textContent = "Current hero rank: unavailable";
+          rankNode.textContent = "unavailable";
         });
     }
   }


### PR DESCRIPTION
### Motivation
- Shortlist diagnostics were rendered using the broad `hero-slot__meta` layout which spread values across the full width and created a visually disconnected row. 
- The goal is to present the diagnostics as a compact, grouped card near the top of the Hero Editor and keep the fields left-aligned and visually close together. 
- The change must preserve existing JS hooks and data attributes so runtime updates continue to work without changing ranking logic or storage.

### Description
- Replaced the `hero-slot__meta` markup in `admin/hero-edit.php` with a dedicated diagnostics block using `hero-diagnostics`, `hero-diagnostics__grid`, `hero-diagnostics__item`, `hero-diagnostics__label`, and `hero-diagnostics__value`, and kept `data-diagnostic-rank`, `data-diagnostic-context`, `data-diagnostic-profile`, and `data-diagnostic-basis` available. 
- Added responsive CSS in `css/admin/hero.css` to render the diagnostics as a compact, left-aligned grid/card with sensible max width and gaps so it looks good on desktop and narrow screens. 
- Adjusted `js/admin/hero.js` so the script writes concise values into the new value elements (removed duplicated label prefixes in JS output) while preserving the same fetch, ranking detection, and diagnostic update logic. 
- No changes were made to ranking/scoring logic, database schema, rationale saving, or autosave behavior, and the Hero Manager card fields were left unchanged.

### Testing
- Ran `php -l admin/hero-edit.php` and it reported no syntax errors. 
- Ran `node --check js/admin/hero.js` and it reported no syntax errors. 
- Ran `git diff --check` and no whitespace or diff errors were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a084b2b4e9483249d574fc37999c99e)