### PR TITLE
Polish Hero Editor shortlist diagnostics wording

### DIFF
--- a/admin/hero-edit.php
+++ b/admin/hero-edit.php
@@ -365,9 +365,9 @@ if ($heroOrient === 'L') {
 $bestPathForReject = $bestCandidate ? $bestCandidate['path'] : '';
 $stagedLabel = $effectiveOverride !== '' ? $effectiveOverride : 'No candidate selected';
 $stagedStatus = $effectiveOverride !== '' ? 'Ready to save' : 'Select a candidate, then save override';
-$activeHeroRankText = 'Unavailable';
+$activeHeroRankText = 'Current hero rank is unavailable.';
 $activeCriteriaProfileText = '';
-$rankingBasisText = '';
+$rankingBasisText = 'Ranking basis is a temporary legacy ranking.';
 $heroContextParts = [];
 
 if ($activeHero !== '') {
@@ -383,6 +383,7 @@ if ($selectedFromQueryValid) {
     $heroContextParts[] = 'Review selection staged (not yet saved)';
 }
 $heroContextText = !empty($heroContextParts) ? implode(' · ', $heroContextParts) : '';
+$showHeroContextDiagnostic = $heroContextText !== '' && $heroContextText !== 'Current hero in use';
 // --------------------------------------------------------
 // 6) Render layout
 // --------------------------------------------------------
@@ -416,9 +417,9 @@ admin_layout_start("Hero Editor");
                 <div class="hero-diagnostics__label">Current hero rank</div>
                 <div class="hero-diagnostics__value" data-diagnostic-rank><?= htmlspecialchars($activeHeroRankText) ?></div>
             </div>
-            <div class="hero-diagnostics__item">
+            <div class="hero-diagnostics__item" data-diagnostic-context-item<?= $showHeroContextDiagnostic ? '' : ' hidden' ?>>
                 <div class="hero-diagnostics__label">Hero context</div>
-                <div class="hero-diagnostics__value" data-diagnostic-context><?= htmlspecialchars($heroContextText !== '' ? $heroContextText : '—') ?></div>
+                <div class="hero-diagnostics__value" data-diagnostic-context><?= htmlspecialchars($heroContextText) ?></div>
             </div>
             <div class="hero-diagnostics__item">
                 <div class="hero-diagnostics__label">Ranking basis</div>

--- a/js/admin/hero.js
+++ b/js/admin/hero.js
@@ -51,8 +51,8 @@ document.addEventListener("DOMContentLoaded", () => {
   };
   const humanizeRankingBasis = basis => {
     const normalized = String(basis || "").trim();
-    if (normalized === "legacy_rank_placeholder") {
-      return "temporary legacy ranking";
+    if (!normalized || normalized === "legacy_rank_placeholder") {
+      return "a temporary legacy ranking";
     }
     return normalized;
   };
@@ -167,6 +167,7 @@ document.addEventListener("DOMContentLoaded", () => {
     const itemId = String(diagnosticsNode.dataset.itemId || "").trim();
     const rankNode = diagnosticsNode.querySelector("[data-diagnostic-rank]");
     const contextNode = diagnosticsNode.querySelector("[data-diagnostic-context]");
+    const contextItemNode = diagnosticsNode.querySelector("[data-diagnostic-context-item]");
     const profileNode = diagnosticsNode.querySelector("[data-diagnostic-profile]");
     const basisNode = diagnosticsNode.querySelector("[data-diagnostic-basis]");
 
@@ -200,14 +201,23 @@ document.addEventListener("DOMContentLoaded", () => {
             }
           }
 
-          rankNode.textContent = heroRankText;
+          if (heroRankText === "#1" || heroRankText === "#2" || heroRankText === "#3") {
+            rankNode.textContent = `Current hero rank is ${heroRankText}.`;
+          } else if (heroRankText === "none selected" || heroRankText === "outside candidate set") {
+            rankNode.textContent = "Current hero rank is unavailable.";
+          } else {
+            rankNode.textContent = `Current hero rank is ${heroRankText}.`;
+          }
 
           if (contextNode) {
             const contextParts = [];
             if (effectiveHeroPath) contextParts.push("Current hero in use");
             if (shortlist?.current_hero?.is_manual_override) contextParts.push("Manual override saved");
-            if (shortlist?.current_hero?.is_in_recommended_candidates) contextParts.push("Included in current top 3");
-            contextNode.textContent = contextParts.length > 0 ? contextParts.join(" · ") : "No active hero context found";
+            if (shortlist?.current_hero?.is_in_recommended_candidates) contextParts.push("Active hero included in current top 3");
+            const contextText = contextParts.join(" · ");
+            const showContext = contextText !== "" && contextText !== "Current hero in use";
+            if (contextItemNode) contextItemNode.hidden = !showContext;
+            if (showContext) contextNode.textContent = contextText;
           }
 
           const profileLabel = humanizeCriteriaProfile(shortlist?.active_criteria_profile || "");
@@ -219,11 +229,11 @@ document.addEventListener("DOMContentLoaded", () => {
           const basisLabel = humanizeRankingBasis(shortlist?.shortlist_basis || "");
           if (basisNode && basisLabel) {
             basisNode.hidden = false;
-            basisNode.textContent = basisLabel;
+            basisNode.textContent = `Ranking basis is ${basisLabel}.`;
           }
         })
         .catch(() => {
-          rankNode.textContent = "unavailable";
+          rankNode.textContent = "Current hero rank is unavailable.";
         });
     }
   }


### PR DESCRIPTION
### Motivation
- Make the Shortlist diagnostics read as concise, natural diagnostic sentences instead of disjoint label/value fragments.
- Avoid showing the redundant "Current hero in use" context when it provides no extra information, while still surfacing useful context like manual overrides or top-3 inclusion.
- Present the ranking basis in human-readable sentence form and avoid exposing the raw `legacy_rank_placeholder` token.

### Description
- Update `admin/hero-edit.php` to set sentence-style defaults and add `$showHeroContextDiagnostic` to server-render-hide the Hero context row when it only contains `Current hero in use`.
- Update `js/admin/hero.js` to render rank as a sentence (e.g., `Current hero rank is #1.` / `Current hero rank is outside top 3 · ranked #4.` / fallback to `Current hero rank is unavailable.`) and to change the catch fallback to the same sentence.
- Change ranking-basis humanization so empty or `legacy_rank_placeholder` maps to `a temporary legacy ranking` and update the UI text to `Ranking basis is ... .`.
- Adjust diagnostic-context JS to only show the Hero context row when there is meaningful extra information (e.g., manual override saved, active hero included in current top 3) and preserve existing hidden/profile hooks.

### Testing
- Ran `php -l admin/hero-edit.php` and it reported no syntax errors (success).
- Ran `node --check js/admin/hero.js` and it reported no syntax errors (success).
- Ran `git diff --check` as part of validation and it produced no whitespace/format issues (success).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a084e73afe88324a58504f6e7e89f02)