### PR TITLE
Hide Hero context diagnostic by default in Hero Editor

### DIFF
--- a/admin/hero-edit.php
+++ b/admin/hero-edit.php
@@ -368,22 +368,27 @@ $stagedStatus = $effectiveOverride !== '' ? 'Ready to save' : 'Select a candidat
 $activeHeroRankText = 'Current hero rank is unavailable.';
 $activeCriteriaProfileText = '';
 $rankingBasisText = 'Ranking basis is a temporary legacy ranking.';
-$heroContextParts = [];
+$showHeroContextDiagnostic = false;
+$heroContextText = '';
 
-if ($activeHero !== '') {
-    $heroContextParts[] = 'Current hero in use';
+if ($showHeroContextDiagnostic) {
+    $heroContextParts = [];
+
+    if ($activeHero !== '') {
+        $heroContextParts[] = 'Current hero in use';
+    }
+    if ($heroImage !== '') {
+        $heroContextParts[] = 'Stored hero image available';
+    }
+    if ($override !== '') {
+        $heroContextParts[] = 'Manual override currently saved';
+    }
+    if ($selectedFromQueryValid) {
+        $heroContextParts[] = 'Review selection staged (not yet saved)';
+    }
+
+    $heroContextText = !empty($heroContextParts) ? implode(' · ', $heroContextParts) : '';
 }
-if ($heroImage !== '') {
-    $heroContextParts[] = 'Stored hero image available';
-}
-if ($override !== '') {
-    $heroContextParts[] = 'Manual override currently saved';
-}
-if ($selectedFromQueryValid) {
-    $heroContextParts[] = 'Review selection staged (not yet saved)';
-}
-$heroContextText = !empty($heroContextParts) ? implode(' · ', $heroContextParts) : '';
-$showHeroContextDiagnostic = $heroContextText !== '' && $heroContextText !== 'Current hero in use';
 // --------------------------------------------------------
 // 6) Render layout
 // --------------------------------------------------------

--- a/js/admin/hero.js
+++ b/js/admin/hero.js
@@ -166,8 +166,13 @@ document.addEventListener("DOMContentLoaded", () => {
   if (diagnosticsNode) {
     const itemId = String(diagnosticsNode.dataset.itemId || "").trim();
     const rankNode = diagnosticsNode.querySelector("[data-diagnostic-rank]");
-    const contextNode = diagnosticsNode.querySelector("[data-diagnostic-context]");
-    const contextItemNode = diagnosticsNode.querySelector("[data-diagnostic-context-item]");
+    const showHeroContextDiagnostic = false;
+    const contextNode = showHeroContextDiagnostic
+      ? diagnosticsNode.querySelector("[data-diagnostic-context]")
+      : null;
+    const contextItemNode = showHeroContextDiagnostic
+      ? diagnosticsNode.querySelector("[data-diagnostic-context-item]")
+      : null;
     const profileNode = diagnosticsNode.querySelector("[data-diagnostic-profile]");
     const basisNode = diagnosticsNode.querySelector("[data-diagnostic-basis]");
 
@@ -209,7 +214,7 @@ document.addEventListener("DOMContentLoaded", () => {
             rankNode.textContent = `Current hero rank is ${heroRankText}.`;
           }
 
-          if (contextNode) {
+          if (showHeroContextDiagnostic && contextNode) {
             const contextParts = [];
             if (effectiveHeroPath) contextParts.push("Current hero in use");
             if (shortlist?.current_hero?.is_manual_override) contextParts.push("Manual override saved");


### PR DESCRIPTION
### Motivation
- The existing “Hero context” diagnostic is redundant and low-value (items like “Current hero in use” are obvious from the Active hero state), so it should be hidden from the default Hero Editor UI while preserving rebuildable logic for later re-enablement.

### Description
- Introduced an explicit feature-disabled flag in the server render path by setting `$showHeroContextDiagnostic = false` and gated the context-string assembly behind that flag in `admin/hero-edit.php` so the context row remains hidden but the logic is maintained.
- Mirrored the same disabled-by-default pattern in `js/admin/hero.js` with `const showHeroContextDiagnostic = false` and only query/update the context DOM nodes when that flag is enabled so client-side fetches cannot re-show the row during normal page load.
- Left ranking/basis diagnostics, scoring, candidate selection, save/reject behavior, database schema, and rationale saving unchanged.

### Testing
- Ran `php -l admin/hero-edit.php` and it reported no syntax errors (success). 
- Ran `node --check js/admin/hero.js` and it reported no syntax errors (success). 
- Ran `git diff --check` and there were no whitespace/errors reported (success).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a085050db1c8324847851d49a820e44)