### PR TITLE
Ensure hidden Hero diagnostics cards are not displayed

### DIFF
--- a/css/admin/hero.css
+++ b/css/admin/hero.css
@@ -258,6 +258,10 @@
     gap: 4px;
 }
 
+.hero-diagnostics__item[hidden] {
+    display: none;
+}
+
 .hero-diagnostics__label {
     font-size: 0.72rem;
     color: var(--text-muted);


### PR DESCRIPTION
### Motivation
- Diagnostic items in the Hero Editor were marked `hidden` by logic but remained visible because the component CSS applied its own `display` rules, leaving an empty "Hero context" card in the shortlist diagnostics grid.

### Description
- Add a scoped CSS rule ` .hero-diagnostics__item[hidden] { display: none; }` to `css/admin/hero.css` so items flagged hidden are removed from layout without changing any PHP/JS, ranking, scoring, selection, DB, or rationale logic.

### Testing
- Ran `git diff --check` which passed, and no PHP or JS files were changed so `php -l` and `node --check` were not required.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a085547abb48324b1578600433f13db)