### PR TITLE
Hero Editor: arrange active hero action buttons in compact horizontal row

### DIFF
--- a/admin/hero-edit.php
+++ b/admin/hero-edit.php
@@ -492,21 +492,23 @@ admin_layout_start("Hero Editor");
             </div>
         </div>
 
-        <div class="hero-card__actions mt-2">
-            <form method="post" style="display:inline;">
-                <button
-                    type="submit"
-                    name="action"
-                    value="clear_override"
-                    class="btn btn-ghost"
-                >
-                    Clear override
-                </button>
-            </form>
+        <div class="hero-card__actions hero-editor-actions mt-2">
+            <div class="hero-editor-actions__row">
+                <form method="post">
+                    <button
+                        type="submit"
+                        name="action"
+                        value="clear_override"
+                        class="btn btn-ghost"
+                    >
+                        Clear override
+                    </button>
+                </form>
 
-            <a href="hero-manager.php" class="btn btn-ghost">
-                Back to Hero Manager
-            </a>
+                <a href="hero-manager.php" class="btn btn-ghost">
+                    Back to Hero Manager
+                </a>
+            </div>
         </div>
     </section>
 

--- a/css/admin/hero.css
+++ b/css/admin/hero.css
@@ -293,6 +293,17 @@
     justify-content: center;
 }
 
+.hero-editor-actions__row {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 8px;
+}
+
+.hero-editor-actions__row form {
+    margin: 0;
+}
+
 .hero-empty {
     font-size: 0.9rem;
     color: var(--text-muted);


### PR DESCRIPTION
### Motivation
- The Active hero state controls were stacked vertically below the active images which looked unpolished compared to the compact diagnostics row, so the buttons should be arranged side-by-side on desktop while remaining below the images and responsive.

### Description
- Wrapped the existing `Clear override` button and `Back to Hero Manager` link in a local container `div.hero-editor-actions__row` inside the `hero-card__actions` area in `admin/hero-edit.php` so the controls remain below the active hero image pair.
- Added scoped CSS in `css/admin/hero.css` for `.hero-editor-actions__row` implementing a compact left-aligned flex row with wrapping (`display: flex; flex-wrap: wrap; align-items: center; gap: 8px;`) and normalized the nested `form` margin.
- Preserved existing button classes, destinations, behaviors, and did not modify any scoring, database schema, rationale saving, candidate selection, save/reject logic, or Hero Manager cleanup.

### Testing
- Ran `php -l admin/hero-edit.php` which returned no syntax errors.
- Ran `git diff --check` which reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0858667fd0832493b5024f8e2ea755)