### PR TITLE
Clarify Hero Editor active/saved hero labels and collapse duplicate DB hero card

### DIFF
--- a/admin/hero-edit.php
+++ b/admin/hero-edit.php
@@ -353,6 +353,23 @@ if ($selectedFromQueryValid) {
 
 $activeHero = $override ?: $heroImage ?: $chosen;
 
+$normalizeHeroPath = static function (string $path): string {
+    $normalized = trim($path);
+    if ($normalized === '') {
+        return '';
+    }
+
+    $normalized = preg_replace('#^[a-z]+://#i', '', $normalized);
+    $normalized = preg_replace('#/{2,}#', '/', $normalized);
+
+    return strtolower(rtrim($normalized, '/'));
+};
+
+$activeHeroNormalized = $normalizeHeroPath($activeHero);
+$storedHeroNormalized = $normalizeHeroPath($heroImage);
+$savedHeroMatchesActiveHero = ($activeHeroNormalized !== '' && $storedHeroNormalized !== '' && $activeHeroNormalized === $storedHeroNormalized);
+$showSavedHeroComparisonCard = ($heroImage !== '' && !$savedHeroMatchesActiveHero);
+
 // Label for stored hero orientation
 $orientLabel = 'Portrait';
 if ($heroOrient === 'L') {
@@ -438,12 +455,12 @@ admin_layout_start("Hero Editor");
     <section class="card mb-3">
         <h2 style="font-size:1.0rem;margin:0 0 10px;">Active hero state</h2>
 
-        <div class="grid grid-2">
+        <div class="grid <?= $showSavedHeroComparisonCard ? 'grid-2' : 'grid-1' ?> hero-active-state-grid">
             <div>
-                <div class="hero-slot__label">
-                    <span>Active hero</span>
+                <div class="hero-slot__label hero-active-state__label">
+                    <span>Current site hero</span>
                     <span class="hero-slot__tag">
-                        <?= $activeHero !== '' ? 'In use' : 'None' ?>
+                        <?= $activeHero !== '' ? 'In use' : 'Not set' ?>
                     </span>
                 </div>
                 <div class="hero-slot__imgwrap mt-1">
@@ -455,25 +472,7 @@ admin_layout_start("Hero Editor");
                         </span>
                     <?php endif; ?>
                 </div>
-            </div>
-
-            <div>
-                <div class="hero-slot__label">
-                    <span>Stored hero_image</span>
-                    <span class="hero-slot__tag">
-                        <?= $heroImage !== '' ? $orientLabel : 'None' ?>
-                    </span>
-                </div>
-                <div class="hero-slot__imgwrap mt-1">
-                    <?php if ($heroImage !== ''): ?>
-                        <?= admin_render_thumbnail_safe($heroImage, "$itemName – stored hero") ?>
-                    <?php else: ?>
-                        <span class="hero-slot__empty">
-                            No stored <code>hero_image</code>; cards use chosen/override instead.
-                        </span>
-                    <?php endif; ?>
-                </div>
-                <div class="hero-slot__meta">
+                <div class="hero-slot__meta hero-active-state__meta">
                     <span>ratio:
                         <?php if ($heroRatio !== null): ?>
                             <?= number_format($heroRatio, 3) ?>
@@ -481,6 +480,9 @@ admin_layout_start("Hero Editor");
                             —
                         <?php endif; ?>
                     </span>
+                    <?php if ($heroOrient !== ''): ?>
+                        <span><?= strtolower($orientLabel) ?></span>
+                    <?php endif; ?>
                     <span>score:
                         <?php if ($heroScore !== null): ?>
                             <?= number_format($heroScore, 1) ?>
@@ -490,8 +492,26 @@ admin_layout_start("Hero Editor");
                     </span>
                 </div>
             </div>
+
+            <?php if ($showSavedHeroComparisonCard): ?>
+                <div>
+                    <div class="hero-slot__label hero-active-state__label">
+                        <span>Saved DB hero</span>
+                        <span class="hero-slot__tag">Differs</span>
+                    </div>
+                    <div class="hero-slot__imgwrap mt-1">
+                        <?= admin_render_thumbnail_safe($heroImage, "$itemName – stored hero") ?>
+                    </div>
+                    <div class="hero-slot__meta hero-active-state__meta">
+                        <span>Saved DB hero differs from current site hero.</span>
+                    </div>
+                </div>
+            <?php endif; ?>
         </div>
 
+        <?php if ($savedHeroMatchesActiveHero): ?>
+            <div class="hero-active-state__status">Saved DB hero matches current site hero.</div>
+        <?php endif; ?>
         <div class="hero-card__actions hero-editor-actions mt-2">
             <div class="hero-editor-actions__row">
                 <form method="post">

--- a/css/admin/hero.css
+++ b/css/admin/hero.css
@@ -982,3 +982,31 @@
 .candidate .hero-slot__label .hero-badge { text-transform:none; letter-spacing:0; }
 .candidate--selected { border-width:2px; }
 @media (max-width: 719px) { .hero-override-summary__body { grid-template-columns: 1fr; } }
+
+.hero-active-state-grid {
+    gap: 10px;
+}
+
+.hero-active-state__label {
+    text-transform: none;
+    letter-spacing: 0.01em;
+}
+
+.hero-active-state__label span {
+    max-width: none;
+    white-space: normal;
+    overflow: visible;
+    text-overflow: clip;
+}
+
+.hero-active-state__meta {
+    justify-content: flex-start;
+    flex-wrap: wrap;
+    gap: 6px;
+}
+
+.hero-active-state__status {
+    margin-top: 8px;
+    font-size: 0.78rem;
+    color: var(--text-muted);
+}


### PR DESCRIPTION
### Motivation
- The Active hero UI used truncated/internal labels (e.g. `STORED HERO_IMA...`, `SQUA...`) and could show the same image twice without explaining why, which confused editors. 
- The goal is to make the distinction between the current/effective hero and the saved DB hero clearer while collapsing duplicate visual clutter when both images refer to the same file. 

### Description
- Added server-side normalized path comparison and booleans (`$activeHeroNormalized`, `$storedHeroNormalized`, `$savedHeroMatchesActiveHero`, `$showSavedHeroComparisonCard`) to detect when the active/effective hero and saved DB hero are the same and to drive rendering decisions in `admin/hero-edit.php`. 
- Updated visible labels and copy in the Active hero state area from `Active hero` → `Current site hero` and `Stored hero_image` → `Saved DB hero`, and added explicit match/differ notes (`Saved DB hero matches current site hero.` / `Saved DB hero differs from current site hero.`). 
- Collapsed the duplicate case to render a single card for the current hero plus a compact status line, and preserved the two-card side-by-side comparison when the heroes differ. 
- Moved orientation into the metadata line (ratio/orientation/score) and added scoped CSS (`.hero-active-state-*`) in `css/admin/hero.css` to prevent truncation and cramped pills while keeping the `Clear override` and `Back to Hero Manager` action row in place. 
- No changes were made to ranking/scoring logic, database schema, rationale saving, snapshot payloads, or candidate save/reject behavior. 

### Testing
- Ran `php -l admin/hero-edit.php` and the file reported no syntax errors. 
- Ran `git diff --check` to surface whitespace/formatting issues and it returned no problems.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a085f147df08324b56bc57f8e38f3f1)