### PR TITLE
Restyle Hero Editor selected override candidate panel

### DIFF
--- a/admin/hero-edit.php
+++ b/admin/hero-edit.php
@@ -538,20 +538,20 @@ admin_layout_start("Hero Editor");
                value="<?= htmlspecialchars($effectiveOverride) ?>">
         <input type="hidden" name="reject_image" value="<?= htmlspecialchars($bestPathForReject) ?>">
 
-        <section class="hero-override-summary" data-override-summary>
+        <section class="hero-override-summary hero-override-panel" data-override-summary>
             <h2>Selected override candidate</h2>
-            <div class="hero-override-summary__body">
-                <div class="hero-override-summary__preview hero-slot__imgwrap" data-override-preview-wrap>
+            <div class="hero-override-summary__body hero-override-panel__body">
+                <div class="hero-override-summary__preview hero-override-panel__preview hero-slot__imgwrap" data-override-preview-wrap>
                     <?php if ($effectiveOverride !== ''): ?>
                         <?= admin_render_thumbnail_safe($effectiveOverride, "$itemName – staged override") ?>
                     <?php else: ?>
                         <span class="hero-slot__empty" data-override-preview-empty>No candidate selected</span>
                     <?php endif; ?>
                 </div>
-                <div class="hero-override-summary__meta">
+                <div class="hero-override-summary__meta hero-override-panel__details">
                     <div class="hero-override-summary__path" data-override-path><?= htmlspecialchars($stagedLabel) ?></div>
                     <div class="hero-override-summary__status" data-override-status><?= htmlspecialchars($stagedStatus) ?></div>
-                    <div class="hero-override-summary__actions">
+                    <div class="hero-override-summary__actions hero-override-panel__actions">
                         <button type="submit" name="action" value="save_override" class="btn btn-primary" data-save-override<?= $effectiveOverride === "" ? " disabled" : "" ?>>
                             <span class="btn__dot"></span>
                             Save override

--- a/css/admin/hero.css
+++ b/css/admin/hero.css
@@ -972,16 +972,40 @@
 .hero-override-summary { border:1px solid rgba(148,163,235,.35); border-radius:12px; padding:12px; background:rgba(15,23,42,.45); }
 .hero-override-summary h2 { margin:0 0 10px; font-size:.95rem; }
 .hero-override-summary__body { display:grid; grid-template-columns:minmax(180px,220px) 1fr; gap:12px; align-items:start; }
+.hero-override-panel__preview {
+    min-height: 148px;
+    padding: 8px;
+    background: rgba(15, 23, 42, 0.45);
+    border: 1px solid rgba(148, 163, 235, 0.22);
+    border-radius: 10px;
+}
+.hero-override-panel__preview .hero-slot__empty {
+    min-height: 128px;
+    font-size: .82rem;
+}
+.hero-override-panel__details {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
 .hero-override-summary__path { font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace; font-size:.74rem; color:#cbd5e1; word-break: break-all; }
-.hero-override-summary__status { font-size:.8rem; color:#93c5fd; margin-top:6px; }
+.hero-override-summary__status { font-size:.8rem; color:#93c5fd; line-height:1.4; }
 .hero-override-summary__actions { display:flex; flex-wrap:wrap; gap:8px; margin-top:10px; }
+.hero-override-panel__actions .btn {
+    white-space: nowrap;
+}
 .card-grid--candidates { grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); align-items: start; }
 .card-grid--candidates .candidate { min-width:0; }
 .card-imagebox { width:100%; max-width:100%; }
 .candidate .hero-slot__label { gap:6px; flex-wrap:wrap; justify-content:flex-start; }
 .candidate .hero-slot__label .hero-badge { text-transform:none; letter-spacing:0; }
 .candidate--selected { border-width:2px; }
-@media (max-width: 719px) { .hero-override-summary__body { grid-template-columns: 1fr; } }
+@media (max-width: 719px) {
+    .hero-override-summary__body { grid-template-columns: 1fr; }
+    .hero-override-panel__preview .hero-slot__empty {
+        min-height: 96px;
+    }
+}
 
 .hero-active-state-grid {
     gap: 10px;


### PR DESCRIPTION
### Motivation
- The "Selected override candidate" section looked visually inconsistent with the redesigned Hero Editor and had an overly large empty preview and vertically stacked action buttons. 
- Update the layout and styling so the section matches the compact two-column style used elsewhere while preserving all backend behavior and wiring.

### Description
- Introduced a local panel wrapper and semantic class names by adding `hero-override-panel`, `hero-override-panel__body`, `hero-override-panel__preview`, `hero-override-panel__details`, and `hero-override-panel__actions` in `admin/hero-edit.php`. 
- Constrained the preview footprint and improved empty-state appearance while keeping the placeholder text `No candidate selected` and existing preview rendering. 
- Reworked CSS in `css/admin/hero.css` to provide a compact two-column layout on desktop, responsive stacking on narrow screens, a tighter preview card, and a compact/wrapping action row with buttons kept on a single row when space allows. 
- Preserved all existing form attributes, button names/values/hrefs, and candidate selection/save/reject/ranking logic; no JS, DB schema, nor rationale logic was changed.

### Testing
- Ran `php -l admin/hero-edit.php` which returned no syntax errors. 
- Ran `git diff --check` which reported no whitespace or diff issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0861deb4948324a5af90e1fe4c923d)