### PR TITLE
Stage 3AW-Fix 13: clarify saved override status and polish Hero Editor override actions

### DIFF
--- a/admin/hero-edit.php
+++ b/admin/hero-edit.php
@@ -381,7 +381,15 @@ if ($heroOrient === 'L') {
 // Best candidate path for "Reject auto choice" button
 $bestPathForReject = $bestCandidate ? $bestCandidate['path'] : '';
 $stagedLabel = $effectiveOverride !== '' ? $effectiveOverride : 'No candidate selected';
-$stagedStatus = $effectiveOverride !== '' ? 'Ready to save' : 'Select a candidate, then save override';
+$effectiveOverrideNormalized = $normalizeHeroPath($effectiveOverride);
+$savedOverrideNormalized = $normalizeHeroPath($override);
+$selectedOverrideIsSaved = ($effectiveOverrideNormalized !== '' && $effectiveOverrideNormalized === $savedOverrideNormalized);
+$stagedStatus = 'Select a candidate, then save override';
+if ($effectiveOverride !== '') {
+    $stagedStatus = $selectedOverrideIsSaved
+        ? 'Saved as current override.'
+        : 'Ready to save';
+}
 $activeHeroRankText = 'Current hero rank is unavailable.';
 $activeCriteriaProfileText = '';
 $rankingBasisText = 'Ranking basis is a temporary legacy ranking.';
@@ -552,8 +560,7 @@ admin_layout_start("Hero Editor");
                     <div class="hero-override-summary__path" data-override-path><?= htmlspecialchars($stagedLabel) ?></div>
                     <div class="hero-override-summary__status" data-override-status><?= htmlspecialchars($stagedStatus) ?></div>
                     <div class="hero-override-summary__actions hero-override-panel__actions">
-                        <button type="submit" name="action" value="save_override" class="btn btn-primary" data-save-override<?= $effectiveOverride === "" ? " disabled" : "" ?>>
-                            <span class="btn__dot"></span>
+                        <button type="submit" name="action" value="save_override" class="btn btn-primary" data-save-override<?= ($effectiveOverride === "" || $selectedOverrideIsSaved) ? " disabled" : "" ?>>
                             Save override
                         </button>
                         <?php if ($bestPathForReject !== ''): ?>
@@ -567,7 +574,7 @@ admin_layout_start("Hero Editor");
             </div>
         </section>
 
-        <h2 style="font-size:1.0rem;margin:0 0 10px;">All candidate images</h2>
+        <h2 class="hero-override-candidates-heading" style="font-size:1.0rem;margin:0 0 10px;">All candidate images</h2>
 
         <?php if (empty($candidates)): ?>
             <p class="hero-empty">

--- a/css/admin/hero.css
+++ b/css/admin/hero.css
@@ -1034,3 +1034,5 @@
     font-size: 0.78rem;
     color: var(--text-muted);
 }
+
+.hero-override-candidates-heading { margin-top: 8px !important; }


### PR DESCRIPTION
### Motivation
- Browser testing showed the Selected override candidate panel was ambiguous after saving because it still said "Ready to save" even when the selection was the already-saved override.  
- The Save override button contained an unnecessary decorative dot and the "All candidate images" heading sat too close to the Selected override panel, causing minor visual clutter.

### Description
- Added normalized-path comparison and a boolean flag `selectedOverrideIsSaved` in `admin/hero-edit.php` to detect when the staged/selected override equals the persisted override and used it to pick unambiguous status copy.  
- Updated the staged status text to show `Ready to save` for staged-but-unsaved selections and `Saved as current override.` when the selected candidate is already saved.  
- Disabled the Save button when there is no selection or when the selected candidate is already the saved override by changing the `data-save-override` disabled condition in `admin/hero-edit.php`.  
- Removed the specific `<span class="btn__dot"></span>` from the Save override button in the Selected override panel (no global `btn__dot` removals).  
- Added a scoped heading class `hero-override-candidates-heading` and a small CSS rule in `css/admin/hero.css` to add spacing above the "All candidate images" heading so it doesn’t crowd the panel above it.  
- Files changed: `admin/hero-edit.php`, `css/admin/hero.css`.

### Testing
- Ran `php -l admin/hero-edit.php` with no syntax errors (succeeded).  
- Ran `git diff --check` and fixed whitespace; result succeeded.  
- No JS changes were made so `node --check` was not run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0864cd889483249102644d9a7e9c73)