### PR TITLE
Polish Hero Editor UI: label, spacing, path styling, and panel width

### DIFF
--- a/admin/hero-edit.php
+++ b/admin/hero-edit.php
@@ -480,7 +480,7 @@ admin_layout_start("Hero Editor");
                         </span>
                     <?php endif; ?>
                 </div>
-                <div class="hero-slot__meta hero-active-state__meta">
+                <div class="hero-slot__meta hero-active-state__meta hero-active-state__meta--primary">
                     <span>ratio:
                         <?php if ($heroRatio !== null): ?>
                             <?= number_format($heroRatio, 3) ?>
@@ -510,7 +510,7 @@ admin_layout_start("Hero Editor");
                     <div class="hero-slot__imgwrap mt-1">
                         <?= admin_render_thumbnail_safe($heroImage, "$itemName – stored hero") ?>
                     </div>
-                    <div class="hero-slot__meta hero-active-state__meta">
+                    <div class="hero-slot__meta hero-active-state__meta hero-active-state__meta--comparison">
                         <span>Saved DB hero differs from current site hero.</span>
                     </div>
                 </div>
@@ -557,7 +557,10 @@ admin_layout_start("Hero Editor");
                     <?php endif; ?>
                 </div>
                 <div class="hero-override-summary__meta hero-override-panel__details">
-                    <div class="hero-override-summary__path" data-override-path><?= htmlspecialchars($stagedLabel) ?></div>
+                    <div class="hero-override-summary__path-wrap">
+                        <span class="hero-override-summary__path-label">Image path</span>
+                        <div class="hero-override-summary__path" data-override-path><?= htmlspecialchars($stagedLabel) ?></div>
+                    </div>
                     <div class="hero-override-summary__status" data-override-status><?= htmlspecialchars($stagedStatus) ?></div>
                     <div class="hero-override-summary__actions hero-override-panel__actions">
                         <button type="submit" name="action" value="save_override" class="btn btn-primary" data-save-override<?= ($effectiveOverride === "" || $selectedOverrideIsSaved) ? " disabled" : "" ?>>
@@ -594,7 +597,7 @@ admin_layout_start("Hero Editor");
                         <div class="hero-slot__label">
                             <span><?= $src === 'chosen' ? 'Chosen image' : 'Thumbnail' ?></span>
                             <?php if ($activeHero === $path): ?><span class="hero-badge hero-badge--manual">Active hero</span><?php endif; ?>
-                            <?php if ($heroImage === $path): ?><span class="hero-badge">Stored hero_image</span><?php endif; ?>
+                            <?php if ($heroImage === $path): ?><span class="hero-badge">Saved DB hero</span><?php endif; ?>
                             <span class="hero-slot__tag">
                                 <?= $src === 'chosen' ? 'Primary' : 'Alt' ?>
                             </span>

--- a/css/admin/hero.css
+++ b/css/admin/hero.css
@@ -971,6 +971,10 @@
 .hero-override-form { gap: 14px; }
 .hero-override-summary { border:1px solid rgba(148,163,235,.35); border-radius:12px; padding:12px; background:rgba(15,23,42,.45); }
 .hero-override-summary h2 { margin:0 0 10px; font-size:.95rem; }
+.hero-override-panel {
+    width: fit-content;
+    max-width: 100%;
+}
 .hero-override-summary__body { display:grid; grid-template-columns:minmax(180px,220px) 1fr; gap:12px; align-items:start; }
 .hero-override-panel__preview {
     min-height: 148px;
@@ -988,7 +992,27 @@
     flex-direction: column;
     gap: 6px;
 }
-.hero-override-summary__path { font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace; font-size:.74rem; color:#cbd5e1; word-break: break-all; }
+.hero-override-summary__path-wrap {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+.hero-override-summary__path-label {
+    font-size: .68rem;
+    text-transform: uppercase;
+    letter-spacing: .05em;
+    color: var(--text-muted);
+}
+.hero-override-summary__path {
+    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+    font-size:.74rem;
+    color:#cbd5e1;
+    word-break: break-all;
+    border: 1px solid rgba(148, 163, 235, 0.24);
+    border-radius: 8px;
+    background: rgba(15, 23, 42, 0.56);
+    padding: 6px 8px;
+}
 .hero-override-summary__status { font-size:.8rem; color:#93c5fd; line-height:1.4; }
 .hero-override-summary__actions { display:flex; flex-wrap:wrap; gap:8px; margin-top:10px; }
 .hero-override-panel__actions .btn {
@@ -1027,6 +1051,12 @@
     justify-content: flex-start;
     flex-wrap: wrap;
     gap: 6px;
+}
+.hero-active-state__meta--primary {
+    margin-top: 8px;
+}
+.hero-active-state__meta--comparison {
+    margin-top: 10px;
 }
 
 .hero-active-state__status {


### PR DESCRIPTION
### Motivation
- Improve visual consistency of the per-item Hero Editor UI without changing any behavior or data model.
- Address mismatched badge text, cramped vertical spacing in the Active hero state, raw-looking image path display, and an overly wide Selected override panel on desktop.

### Description
- Renamed the candidate badge text in the All candidate images section from `Stored hero_image` to `Saved DB hero` in `admin/hero-edit.php` to match the Active hero state wording.
- Introduced scoped meta classes (`hero-active-state__meta--primary` and `hero-active-state__meta--comparison`) and added top margins in `css/admin/hero.css` to give more vertical breathing room for the ratio/orientation/score line and the saved/current relationship text.
- Kept the selected override image path visible but wrapped it in an `Image path` label and styled it as a compact monospace boxed row by adding markup in `admin/hero-edit.php` and corresponding styles in `css/admin/hero.css`.
- Made the Selected override candidate panel narrower on desktop by adding a scoped rule (`.hero-override-panel { width: fit-content; max-width: 100%; }`) so the panel fits its content while preserving responsive behavior on small screens.
- Preserved all existing behavior and logic, including candidate selection, save/reject flows, DB schema, and rationale handling; no JavaScript, migration, or DB code was modified.

### Testing
- Ran `php -l admin/hero-edit.php` with no syntax errors (success).
- Ran `git diff --check` to validate whitespace/trailing issues (no problems found).
- Did not run `node --check` because no JavaScript files were changed (not applicable).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08685e096c832495d003ec4ecfdcbe)