### PR TITLE
Polish Hero Manager slot labels and metadata display

### DIFF
--- a/admin/hero-manager.php
+++ b/admin/hero-manager.php
@@ -545,7 +545,7 @@ admin_layout_start("Hero Manager");
                         <!-- badges -->
                         <div class="hero-card__badges">                            
                             <?php if ($override): ?>
-                                <span class="hero-badge hero-badge--manual">Manual override</span>
+                                <span class="hero-badge hero-badge--manual">Manual override active</span>
                             <?php elseif ($rejects > 0): ?>
                                 <span class="hero-badge hero-badge--governed">Governed automation</span>
                             <?php else: ?>
@@ -556,10 +556,6 @@ admin_layout_start("Hero Manager");
                                 <?= $score !== null ? "Score: " . number_format($score, 1) : "No score" ?>
                             </span>
                             <span class="hero-badge hero-badge--orientation<?= $orient === 'S' ? ' is-square' : '' ?>"><?= $orientLabel ?></span>
-
-                            <?php if ($override): ?>
-                                <span class="hero-badge hero-badge--override">Override active</span>
-                            <?php endif; ?>
 
 
                             <?php if ($autoImg && !admin_image_exists($autoImg)): ?>
@@ -596,7 +592,7 @@ admin_layout_start("Hero Manager");
                         <div class="hero-slot__label">
                             <span>Current hero</span>
                             <span class="hero-slot__tag">
-                                <?= $currentHeroSource === 'manual' ? 'Manual' : 'Auto-selected' ?>
+                                <?= $currentHeroSource === 'manual' ? 'Manual override' : 'Auto baseline' ?>
                             </span>
                         </div>
 
@@ -612,8 +608,12 @@ admin_layout_start("Hero Manager");
                         </div>
 
                         <div class="hero-slot__meta">
-                            <span>ratio: <?= $ratio !== null ? number_format($ratio, 3) : '—' ?></span>
-                            <span>score: <?= $score !== null ? number_format($score, 1) : '—' ?></span>
+                            <?php $metaBits = [
+                                'ratio: ' . ($ratio !== null ? number_format($ratio, 3) : '—'),
+                                strtolower($orientLabel),
+                                'score: ' . ($score !== null ? number_format($score, 1) : '—'),
+                            ]; ?>
+                            <span><?= htmlspecialchars(implode(' · ', $metaBits)) ?></span>
                         </div>
                     </div>
 

--- a/css/admin/hero.css
+++ b/css/admin/hero.css
@@ -188,19 +188,20 @@
 
 .hero-slot__label {
     font-size: 0.7rem;
-    text-transform: uppercase;
-    letter-spacing: 0.05em;
+    letter-spacing: 0.02em;
     color: var(--text-muted);
     display: flex;
     justify-content: space-between;
     align-items: center;
+    gap: 6px;
+    flex-wrap: wrap;
 }
 
-.hero-slot__label span {
-    max-width: 70%;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
+.hero-slot__label > span:first-child {
+    flex: 1 1 auto;
+    min-width: 0;
+    color: #dbe7ff;
+    font-weight: 600;
 }
 
 .hero-slot__tag {
@@ -231,10 +232,13 @@
 
 .hero-slot__meta {
     font-size: 0.72rem;
-    color: var(--text-muted);
-    display: flex;
-    justify-content: space-between;
-    gap: 6px;
+    color: #cbd5e1;
+    line-height: 1.35;
+}
+
+.hero-slot__meta span {
+    display: block;
+    white-space: normal;
 }
 
 .hero-diagnostics {


### PR DESCRIPTION
### Motivation
- The Hero Manager UI showed truncated slot labels (e.g. `CURRENT...`, `MA...`, `COMPUTED...`) and cramped metadata that reduced readability compared to the cleaned-up Hero Editor language. The change aims to improve label clarity and metadata layout without touching ranking, scoring, rationale saving, or selection behavior.

### Description
- Updated `admin/hero-manager.php` to replace the left-side manual badges with a single clearer badge (`Manual override active`) and removed the redundant `Override active` pill to reduce visual duplication.
- Changed the current hero slot tag copy to `Manual override` / `Auto baseline` and left the computed slot labeled `Computed baseline` / `Auto`, and reformatted the current hero metadata into a compact single line built from `ratio`, `orientation`, and `score` (assembled via `$metaBits` and `implode(' · ', ...)`).
- Adjusted `css/admin/hero.css` to stop forcing uppercase/ellipsis truncation for slot labels, allow wrapping and emphasize the primary label text, and tuned `.hero-slot__meta` styling to support the compact inline metadata string and better flow on narrow cards.
- No JavaScript, scoring logic, database schema, rationale save, snapshot payload, or Hero Editor behavior was changed.

### Testing
- Ran `php -l admin/hero-manager.php` and received no syntax errors, indicating the PHP changes are syntactically valid (success).
- Ran `git diff --check` to verify there are no whitespace/diff issues (success).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0aa40e54948324937d262124279b44)