### PR TITLE
Remove decorative dot from Hero Manager Edit hero button

### DIFF
--- a/admin/hero-manager.php
+++ b/admin/hero-manager.php
@@ -570,7 +570,7 @@ admin_layout_start("Hero Manager");
 
                         <div class="hero-card__actions" aria-label="Hero item actions">
                             <a class="btn btn-primary" href="hero-edit.php?id=<?= $itemId ?>">
-                                <span class="btn__dot"></span> Edit hero
+                                Edit hero
                             </a>
 
                             <a class="btn btn-ghost" href="hero-manager.php?recalc=<?= $itemId ?>">


### PR DESCRIPTION
### Motivation
- The Edit hero button in the Hero Manager displayed a small decorative dot that looked like an unintended bullet and was inconsistent with the Hero Editor, so it should be removed for a cleaner admin UI.

### Description
- Removed the `<span class="btn__dot"></span>` markup from the Edit hero anchor in `admin/hero-manager.php` while preserving the `btn btn-primary` classes and the `hero-edit.php?id=...` link; change is scoped to this file only and does not remove `btn__dot` globally.

### Testing
- Ran `php -l admin/hero-manager.php` which reported no syntax errors, and ran `git diff --check` which reported no whitespace or diff issues; both checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0aa592be0c83248007b3fbf20a48dd)