### PR TITLE
Compact Hero Manager item action buttons into a single row

### DIFF
--- a/admin/hero-manager.php
+++ b/admin/hero-manager.php
@@ -568,12 +568,12 @@ admin_layout_start("Hero Manager");
 
                         </div>
 
-                        <div class="hero-card__actions" aria-label="Hero item actions">
-                            <a class="btn btn-primary" href="hero-edit.php?id=<?= $itemId ?>">
+                        <div class="hero-card__actions hero-card__actions--compact" aria-label="Hero item actions">
+                            <a class="btn btn-primary hero-card__action-button hero-card__action-button--primary" href="hero-edit.php?id=<?= $itemId ?>">
                                 Edit hero
                             </a>
 
-                            <a class="btn btn-ghost" href="hero-manager.php?recalc=<?= $itemId ?>">
+                            <a class="btn btn-ghost hero-card__action-button hero-card__action-button--secondary" href="hero-manager.php?recalc=<?= $itemId ?>">
                                 Recalculate
                             </a>
                         </div>

--- a/css/admin/hero.css
+++ b/css/admin/hero.css
@@ -286,7 +286,8 @@
 
 .hero-card__actions {
     display: flex;
-    flex-direction: column;
+    flex-direction: row;
+    flex-wrap: wrap;
     align-items: flex-start;
     gap: 8px;
     margin-top: 10px;
@@ -295,6 +296,23 @@
 .hero-card__actions .btn {
     min-width: 132px;
     justify-content: center;
+}
+
+.hero-card__actions--compact {
+    align-items: center;
+}
+
+.hero-card__action-button {
+    min-height: 32px;
+    padding: 6px 12px;
+    font-size: 0.82rem;
+    font-weight: 600;
+    line-height: 1.2;
+    border-radius: 999px;
+}
+
+.hero-card__action-button--primary {
+    box-shadow: none;
 }
 
 .hero-editor-actions__row {
@@ -371,11 +389,6 @@
 
     .hero-list .hero-card__insights {
         grid-column: 1 / -1;
-    }
-
-    .hero-list .hero-card__actions {
-        flex-direction: row;
-        flex-wrap: wrap;
     }
 
     .hero-list .hero-card > .context-note {


### PR DESCRIPTION
### Motivation

- Make the left-side hero item action buttons visually lighter and consistent with the pill-style status badges while preserving existing behavior and click targets.  
- Keep the actions inside the left-side details area and allow the row to wrap on narrow viewports.  
- Avoid touching scoring, DB schema, rationale saving, shortlist/candidate loading, or Hero Editor behavior.

### Description

- Updated the action markup in `admin/hero-manager.php` to add a scoped container class `hero-card__actions--compact` and button classes `hero-card__action-button` and `hero-card__action-button--primary/--secondary` while preserving the existing `href` targets for `hero-edit.php?id=...` and `hero-manager.php?recalc=...`.  
- Switched `.hero-card__actions` layout to a horizontal flex row with wrapping by changing `flex-direction` to `row` and adding `flex-wrap: wrap`.  
- Added scoped compact styles in `css/admin/hero.css` to reduce vertical padding/height, adjust typography, and apply pill-like rounded corners via `.hero-card__action-button` while keeping readable sizing and click targets.  
- Kept existing `.hero-card__actions .btn` `min-width` behavior and removed the prior breakpoint-only override so the compact action layout applies consistently with responsive wrapping.

### Testing

- Ran `php -l admin/hero-manager.php` and it returned `No syntax errors detected`.  
- Ran `git diff --check` and it reported no whitespace or diff-check issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0aa753d5f48324843553fc246977e7)