### PR TITLE
Hero Editor: add product-selection landing page for no-id access

### DIFF
--- a/admin/hero-edit.php
+++ b/admin/hero-edit.php
@@ -12,13 +12,108 @@ require_once __DIR__ . '/../inc/hero/authority.php';
 // --------------------------------------------------------
 $itemId = isset($_GET['id']) ? (int)$_GET['id'] : 0;
 if ($itemId <= 0) {
+    $landingSql = "
+        SELECT
+            i.itemId,
+            i.itemName,
+            i.brand,
+            i.gender,
+            i.age_group,
+            i.categoryName,
+            i.subcategory
+        FROM item i
+        WHERE i.is_active = 1
+        ORDER BY i.brand ASC, i.itemName ASC, i.itemId ASC
+    ";
+    $landingItems = $pdo->query($landingSql)->fetchAll(PDO::FETCH_ASSOC);
+
+    $itemsByBrand = [];
+    foreach ($landingItems as $landingItem) {
+        $brandKey = trim((string)($landingItem['brand'] ?? ''));
+        if ($brandKey === '') {
+            $brandKey = 'Unbranded';
+        }
+        if (!isset($itemsByBrand[$brandKey])) {
+            $itemsByBrand[$brandKey] = [];
+        }
+        $itemsByBrand[$brandKey][] = $landingItem;
+    }
+
+    uksort($itemsByBrand, 'strcasecmp');
+
     admin_layout_start("Hero Editor");
     ?>
-    <div class="admin-wrapper">
-        <p class="flash flash--error">
-            <span class="flash__pill"></span>
-            <span>Missing or invalid <code>id</code> parameter.</span>
-        </p>
+    <div class="hero-admin hero-landing">
+        <header class="hero-admin__header">
+            <h1 class="hero-admin__title">Hero Editor</h1>
+            <p class="hero-admin__subtitle hero-landing__subtitle">Choose a product to edit</p>
+            <p class="hero-landing__intro">
+                The Hero Editor works on one product at a time. Select a product below, or open Hero Manager for the full overview.
+            </p>
+            <div class="hero-landing__actions">
+                <a class="btn btn--primary" href="hero-manager.php">Open Hero Manager</a>
+            </div>
+        </header>
+
+        <section class="hero-landing__panel" aria-label="Products by brand">
+            <h2 class="hero-landing__section-title">Products by brand</h2>
+
+            <?php if (empty($itemsByBrand)): ?>
+                <p class="hero-landing__empty">No active products were found.</p>
+            <?php else: ?>
+                <div class="hero-landing__brands">
+                    <?php foreach ($itemsByBrand as $brandName => $brandItems): ?>
+                        <details class="hero-landing__brand"<?= count($brandItems) <= 8 ? ' open' : '' ?>>
+                            <summary class="hero-landing__brand-summary">
+                                <span class="hero-landing__brand-name"><?= htmlspecialchars($brandName) ?></span>
+                                <span class="hero-landing__brand-count"><?= count($brandItems) ?></span>
+                            </summary>
+                            <div class="hero-landing__rows">
+                                <?php foreach ($brandItems as $product): ?>
+                                    <?php
+                                        $itemIdText = (string)($product['itemId'] ?? '');
+                                        $itemNameText = trim((string)($product['itemName'] ?? 'Untitled item'));
+                                        $brandText = trim((string)($product['brand'] ?? ''));
+                                        $genderText = trim((string)($product['gender'] ?? ''));
+                                        $ageGroupText = trim((string)($product['age_group'] ?? ''));
+                                        $categoryText = trim((string)($product['categoryName'] ?? ''));
+                                        $subcategoryText = trim((string)($product['subcategory'] ?? ''));
+
+                                        $demographic = $genderText !== '' ? $genderText : $ageGroupText;
+                                        $taxonomy = '';
+                                        if ($categoryText !== '' && $subcategoryText !== '') {
+                                            $taxonomy = $categoryText . ' / ' . $subcategoryText;
+                                        } elseif ($categoryText !== '') {
+                                            $taxonomy = $categoryText;
+                                        } elseif ($subcategoryText !== '') {
+                                            $taxonomy = $subcategoryText;
+                                        }
+                                    ?>
+                                    <article class="hero-landing__row">
+                                        <div class="hero-landing__row-main">
+                                            <p class="hero-landing__row-title">
+                                                <span class="hero-landing__item-id">#<?= htmlspecialchars($itemIdText) ?></span>
+                                                <span class="hero-landing__item-name"><?= htmlspecialchars($itemNameText) ?></span>
+                                            </p>
+                                            <p class="hero-landing__row-meta">
+                                                <span><?= htmlspecialchars($brandText !== '' ? $brandText : 'Unbranded') ?></span>
+                                                <?php if ($demographic !== ''): ?>
+                                                    <span>· <?= htmlspecialchars($demographic) ?></span>
+                                                <?php endif; ?>
+                                                <?php if ($taxonomy !== ''): ?>
+                                                    <span>· <?= htmlspecialchars($taxonomy) ?></span>
+                                                <?php endif; ?>
+                                            </p>
+                                        </div>
+                                        <a class="btn btn--ghost btn--small" href="hero-edit.php?id=<?= urlencode($itemIdText) ?>">Edit hero</a>
+                                    </article>
+                                <?php endforeach; ?>
+                            </div>
+                        </details>
+                    <?php endforeach; ?>
+                </div>
+            <?php endif; ?>
+        </section>
     </div>
     <?php
     admin_layout_end();

--- a/css/admin/hero.css
+++ b/css/admin/hero.css
@@ -1083,3 +1083,142 @@
 }
 
 .hero-override-candidates-heading { margin-top: 8px !important; }
+
+/* =========================================================
+   hero-edit — no-id landing selector
+========================================================= */
+
+.hero-landing {
+    display: flex;
+    flex-direction: column;
+    gap: 14px;
+}
+
+.hero-landing__subtitle {
+    margin: 0;
+    font-size: 1.05rem;
+    color: #dbeafe;
+}
+
+.hero-landing__intro {
+    margin: 0;
+    max-width: 840px;
+    color: var(--text-muted);
+    line-height: 1.45;
+}
+
+.hero-landing__actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+}
+
+.hero-landing__panel {
+    background: linear-gradient(135deg, var(--card-bg), #10182b);
+    border: 1px solid var(--card-border);
+    border-radius: 16px;
+    padding: 14px;
+}
+
+.hero-landing__section-title {
+    margin: 0 0 10px;
+    font-size: 1rem;
+    color: #e2e8f0;
+}
+
+.hero-landing__brands {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+}
+
+.hero-landing__brand {
+    border: 1px solid rgba(148, 163, 235, 0.35);
+    border-radius: 12px;
+    background: rgba(2, 6, 23, 0.5);
+    overflow: hidden;
+}
+
+.hero-landing__brand-summary {
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 10px;
+    list-style: none;
+    padding: 10px 12px;
+    font-weight: 600;
+}
+
+.hero-landing__brand-summary::-webkit-details-marker {
+    display: none;
+}
+
+.hero-landing__brand-name {
+    color: #e5edff;
+}
+
+.hero-landing__brand-count {
+    padding: 3px 7px;
+    border-radius: 999px;
+    border: 1px solid rgba(148, 163, 235, 0.5);
+    color: #c7d2ff;
+    font-size: 0.72rem;
+}
+
+.hero-landing__rows {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    padding: 0 10px 10px;
+}
+
+.hero-landing__row {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 10px;
+    border: 1px solid rgba(148, 163, 184, 0.28);
+    border-radius: 10px;
+    padding: 8px 10px;
+    background: rgba(15, 23, 42, 0.55);
+}
+
+.hero-landing__row-title,
+.hero-landing__row-meta {
+    margin: 0;
+}
+
+.hero-landing__row-title {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    font-size: 0.9rem;
+}
+
+.hero-landing__item-id {
+    color: #c7d2fe;
+}
+
+.hero-landing__item-name {
+    color: #f8fafc;
+    font-weight: 600;
+}
+
+.hero-landing__row-meta {
+    color: var(--text-muted);
+    font-size: 0.78rem;
+    margin-top: 3px;
+}
+
+.hero-landing__empty {
+    margin: 0;
+    color: var(--text-muted);
+}
+
+@media (max-width: 760px) {
+    .hero-landing__row {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+}


### PR DESCRIPTION
### Motivation

- The Hero Editor previously showed a blunt "Missing or invalid id parameter" error when opened without an `id`, which is poor UX since the editor is present in the admin sidebar. 
- Provide a useful entry screen that keeps the Hero Editor item-scoped while giving users an easy way to choose a product to edit.

### Description

- Replace the invalid-id error branch in `admin/hero-edit.php` with a DB-backed landing flow that queries active items and groups them by `brand` for display. 
- Render a compact landing UI inside the existing admin layout with header copy, a primary `Open Hero Manager` CTA, and collapsible brand sections implemented with `<details>/<summary>`.
- Each product row displays escaped metadata (item ID, item name, brand, demographic from `gender`/`age_group`, and `categoryName`/`subcategory` when present) and an `Edit hero` link to `hero-edit.php?id=...` (IDs are URL-encoded and fields are escaped with `htmlspecialchars`).
- Add landing styles to `css/admin/hero.css` to match the dark admin UI and keep large brand sections readable, while preserving the existing valid-id Hero Editor behavior and all scoring/ranking and database logic unchanged.

### Testing

- Ran `php -l admin/hero-edit.php` and it reported no syntax errors. 
- Ran `git diff --check` and it reported no whitespace or diff problems.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ab754b00c8324af487e9fd4761774)