### PR TITLE
Refine Image Integrity report severity rules to reduce false positives

### DIFF
--- a/admin/image-integrity.php
+++ b/admin/image-integrity.php
@@ -35,6 +35,8 @@ $rows = $pdo->query($sql)->fetchAll(PDO::FETCH_ASSOC);
 $allBrands = [];
 $imageRefs = [];
 $duplicateMap = [];
+$duplicateUsageMap = [];
+$itemEffectiveHeroRawMap = [];
 
 $referenceBuilder = static function (array $item, string $source, string $rawPath, bool $isEffectiveHero) {
     $rawPath = trim($rawPath);
@@ -67,6 +69,7 @@ foreach ($rows as $item) {
     $heroImage = trim((string)($item['hero_image'] ?? ''));
     $chosenImage = trim((string)($item['chosen_image'] ?? ''));
     $effectiveHero = $overrideImage !== '' ? $overrideImage : ($heroImage !== '' ? $heroImage : $chosenImage);
+    $itemEffectiveHeroRawMap[(int)$item['itemId']] = ($effectiveHero !== '');
 
     $refsForItem = [];
     $refsForItem[] = $referenceBuilder($item, 'chosen_image', $chosenImage, $effectiveHero !== '' && $effectiveHero === $chosenImage);
@@ -87,6 +90,11 @@ foreach ($rows as $item) {
         if ($ref['normalized_path'] !== '') {
             $key = strtolower($ref['normalized_path']);
             $duplicateMap[$key] = ($duplicateMap[$key] ?? 0) + 1;
+            $itemKey = (string)$ref['itemId'];
+            $sourceKey = (string)$ref['source'];
+            $duplicateUsageMap[$key] = $duplicateUsageMap[$key] ?? ['items' => [], 'sources' => []];
+            $duplicateUsageMap[$key]['items'][$itemKey] = true;
+            $duplicateUsageMap[$key]['sources'][$sourceKey] = ($duplicateUsageMap[$key]['sources'][$sourceKey] ?? 0) + 1;
         }
     }
 }
@@ -120,9 +128,15 @@ foreach ($imageRefs as $ref) {
     $outsideExpectedRoot = false;
     $exists = false;
 
+    $isVideo = !$isBlank && (bool)preg_match('/\.mp4($|\?)/i', $raw);
+
     if ($isBlank) {
-        $notes[] = 'Blank path.';
-        $severity = 'critical';
+        $notes[] = ($ref['source'] === 'chosen_image' || $ref['source'] === 'override_image')
+            ? 'Blank path (optional unless needed as effective hero).'
+            : 'Blank path.';
+        if ($ref['source'] === 'hero_image' || $ref['source'] === 'thumbnail_candidate') {
+            $severity = 'warning';
+        }
     }
 
     if ($isExternal) {
@@ -133,6 +147,10 @@ foreach ($imageRefs as $ref) {
     if ($hasBackslashes) {
         $notes[] = 'Path contains backslashes.';
         if ($severity !== 'critical') $severity = 'warning';
+    }
+
+    if ($isVideo) {
+        $notes[] = 'Media/video reference (.mp4), not a still-image asset.';
     }
 
     if (!$isBlank && !$isExternal) {
@@ -183,9 +201,21 @@ foreach ($imageRefs as $ref) {
     }
 
     $dupCount = $normalized !== '' ? (int)($duplicateMap[strtolower($normalized)] ?? 0) : 0;
-    if ($dupCount > 1) {
-        $notes[] = 'Duplicate path reused across references (' . $dupCount . ' uses).';
-        if ($severity !== 'critical') $severity = 'warning';
+    if ($dupCount > 1 && $normalized !== '') {
+        $dupMeta = $duplicateUsageMap[strtolower($normalized)] ?? ['items' => [], 'sources' => []];
+        $crossItemReuse = count($dupMeta['items']) > 1;
+        $sameSourceRepeat = false;
+        foreach (($dupMeta['sources'] ?? []) as $sourceCount) {
+            if ((int)$sourceCount > 1) {
+                $sameSourceRepeat = true;
+                break;
+            }
+        }
+
+        if ($crossItemReuse || $sameSourceRepeat) {
+            $notes[] = 'Suspicious duplicate path reuse (' . $dupCount . ' uses).';
+            if ($severity !== 'critical') $severity = 'warning';
+        }
     }
 
     $itemId = $ref['itemId'];
@@ -221,6 +251,16 @@ foreach ($imageRefs as $ref) {
 }
 
 foreach ($itemCandidateStats as $itemId => $stats) {
+    if (($itemEffectiveHeroRawMap[$itemId] ?? false) === false) {
+        foreach ($finalRows as &$rowRef) {
+            if ($rowRef['itemId'] === $itemId) {
+                $rowRef['notes'] .= ($rowRef['notes'] !== '' ? ' ' : '') . 'Missing current effective hero image.';
+                $rowRef['severity'] = 'critical';
+            }
+        }
+        unset($rowRef);
+    }
+
     if ($stats['total'] > 0 && $stats['exists'] === 0) {
         foreach ($finalRows as &$rowRef) {
             if ($rowRef['itemId'] === $itemId) {


### PR DESCRIPTION
### Motivation
- Reduce noisy false positives in the Image Integrity report so expected states (blank `chosen_image`/`override_image`, hero/thumb overlap, and video refs) do not dominate warnings.
- Better distinguish true integrity failures (missing effective hero, all candidates missing, malformed/outside-root paths) from acceptable data shapes.
- Identify video/media references such as `.mp4` so they are labeled as media rather than treated exactly like still-image candidates.

### Description
- Track duplicate usage context by adding `duplicateUsageMap` to record which `itemId`s and `source`s reference each normalized path and only flag duplicates when they are cross-item reuse or repeated within the same source list.
- Add `itemEffectiveHeroRawMap` to detect when no effective hero raw path exists for an item and escalate that condition to `critical` at the item level.
- Change blank-path handling so `chosen_image` and `override_image` blanks are treated as optional/info, while blank `hero_image` and `thumbnail_candidate` become `warning` (not automatically `critical`).
- Add `isVideo` detection for `.mp4` and emit a classification note `Media/video reference (.mp4), not a still-image asset.` while keeping existing malformed/outside-root, missing `/brands/`, backslash, and extension-mismatch logic intact.

### Testing
- Ran `php -l admin/image-integrity.php` and the syntax check passed successfully.
- Ran `git diff --check` and there were no whitespace or diff errors.
- Committed the change to `admin/image-integrity.php` after validation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ae7e138848324aafe03a702e53d7d)