### PR TITLE
Add read-only CSV↔MySQL image reconciliation report generator

### DIFF
--- a/tools/reports/image-sync-reconciliation.php
+++ b/tools/reports/image-sync-reconciliation.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Read-only CSV ↔ MySQL image-path reconciliation report generator.
+ *
+ * Usage:
+ *   php tools/reports/image-sync-reconciliation.php
+ *   C:\laragon\bin\php\php-8.1.10-Win32-vs16-x64\php.exe tools\reports\image-sync-reconciliation.php
+ */
+if (PHP_SAPI !== 'cli') { fwrite(STDERR, "CLI-only.\n"); exit(1);} 
+$root = dirname(__DIR__, 2);
+$csvPath = $root . '/docs/data/SportWarehouse_ProductDB.csv';
+$reportPath = $root . '/docs/operations/generated/image-sync-reconciliation-report.csv';
+$summaryPath = $root . '/docs/operations/generated/image-sync-reconciliation-summary.md';
+$imagesRoot = $root . '/images';
+$reportHeaders = ['match_status','confidence','csv_row_number','csv_db_itemId','mysql_itemId','csv_brand','mysql_brand','csv_itemName','mysql_itemName','csv_gender','mysql_gender_or_demographic','csv_images','csv_thumbnails_json','mysql_thumbnails_json','thumbnails_compare_status','csv_videos','mysql_hero_image','mysql_chosen_image','override_chosen_image','hero_status','override_status','filesystem_status','recommended_action','notes'];
+$counts = ['total CSV rows'=>0,'total active MySQL items considered'=>0,'matched rows'=>0,'in_sync'=>0,'mysql_stale_relative_to_csv'=>0,'csv_future_or_staging'=>0,'csv_only_candidate'=>0,'mysql_only_legacy'=>0,'ambiguous_match'=>0,'manual_review_required'=>0,'rows where CSV thumbnails_json is nonblank and MySQL thumbnails_json differs'=>0,'rows where local files are missing for CSV paths'=>0,'rows where local files are missing for MySQL paths'=>0];
+function mustSelect(string $sql): void { if (!preg_match('/^SELECT\b/i', ltrim($sql))) throw new RuntimeException('Refusing non-SELECT SQL.'); }
+function qAll(PDO $pdo, string $sql, array $params=[]): array { mustSelect($sql); $s=$pdo->prepare($sql); $s->execute($params); return $s->fetchAll(PDO::FETCH_ASSOC);} 
+function norm(?string $v): string { return preg_replace('/[^a-z0-9]+/', '', strtolower(trim((string)$v))) ?? ''; }
+function parsePathList(?string $v): array { $v=trim((string)$v); if($v==='') return []; return array_values(array_filter(array_map('trim', preg_split('/\s*,\s*/',$v) ?: []), fn($x)=>$x!=='')); }
+function parseJsonArray(?string $v): array { $v=trim((string)$v); if($v==='') return []; $d=json_decode($v,true); if(!is_array($d)) return []; return array_values(array_filter(array_map(fn($x)=>trim((string)$x),$d),fn($x)=>$x!=='')); }
+function pathExistsLocal(string $imagesRoot, string $path): bool { $p=ltrim(str_replace('\\','/',trim($path)),'/'); if($p==='') return true; if(str_starts_with($p,'images/')) return is_file(dirname($imagesRoot).'/'.$p); return is_file($imagesRoot.'/'.$p); }
+function thumbsCompare(string $csv, string $mysql): string { $c=parseJsonArray($csv); $m=parseJsonArray($mysql); if(!$c&&!$m) return 'both_blank'; if(!$c&&$m) return 'csv_blank_mysql_nonblank'; if($c&&!$m) return 'mysql_blank_csv_nonblank'; if($c===$m) return 'identical'; $a=$c;$b=$m;sort($a);sort($b); if($a===$b) return 'same_set_different_order'; if(count(array_filter($c,fn($p)=>str_contains($p,'/brands/')))>0&&count(array_filter($m,fn($p)=>!str_contains($p,'/brands/')))>0) return 'csv_has_brands_path_mysql_legacy'; if(count(array_filter($c,fn($p)=>substr_count($p,'/')>=3))>0) return 'csv_has_extra_path_segments'; return 'csv_different_folder_or_filename'; }
+require $root . '/db.php';
+$items=qAll($pdo,"SELECT itemId, brand, itemName, demographic, thumbnails_json, hero_image, chosen_image FROM item");
+$counts['total active MySQL items considered']=count($items);
+$hasOverride=(int)(qAll($pdo,"SELECT COUNT(*) c FROM information_schema.tables WHERE table_schema=DATABASE() AND table_name='hero_override'")[0]['c']??0)>0;
+$overrideById=[]; if($hasOverride){ foreach(qAll($pdo,"SELECT itemId, chosen_image FROM hero_override") as $r){$overrideById[(int)$r['itemId']]=(string)($r['chosen_image']??'');}}
+$index=[];$itemById=[]; foreach($items as $it){$id=(int)$it['itemId'];$itemById[$id]=$it;$index[norm($it['brand']).'|'.norm($it['itemName'])][]=$it;}
+@mkdir(dirname($reportPath),0777,true);
+$in=fopen($csvPath,'rb'); $out=fopen($reportPath,'wb'); fputcsv($out,$reportHeaders); $headers=fgetcsv($in)?:[]; $h=[]; foreach($headers as $i=>$name){$h[trim((string)$name)]=$i;} $rowNum=1; $matched=[];
+while(($line=fgetcsv($in))!==false){$rowNum++;$counts['total CSV rows']++; $get=fn($k)=>isset($h[$k],$line[$h[$k]])?trim((string)$line[$h[$k]]):'';
+$csvBrand=$get('brand');$csvName=$get('itemName');$csvDbId=$get('db_itemId');$csvGender=$get('gender');$csvImages=$get('images');$csvThumbs=$get('thumbnails_json');$csvVideos=$get('videos');
+$cands=$index[norm($csvBrand).'|'.norm($csvName)]??[]; $sel=null;$status='manual_review_required';$conf='low';$notes=[];
+if(count($cands)===1){$sel=$cands[0];$conf='high';} elseif(count($cands)>1){$status='ambiguous_match';$counts['ambiguous_match']++;$notes[]='Multiple MySQL rows match normalized brand+itemName.';} else {$status=$csvDbId===''?'csv_future_or_staging':'csv_only_candidate';$counts[$status]++;$conf=$csvDbId===''?'medium':'low';$notes[]='No MySQL match by normalized brand+itemName.';}
+$mysql=['id'=>'','brand'=>'','name'=>'','gender'=>'','thumbs'=>'','hero'=>'','chosen'=>'','override'=>''];$heroStatus='protected_fields_no_blind_overwrite';$overrideStatus=$hasOverride?'override_table_present':'override_table_missing';$thumbStatus='manual_review_required';$fs='not_checked';$action='manual_review_required';
+if($sel){$mysql=['id'=>(string)$sel['itemId'],'brand'=>(string)$sel['brand'],'name'=>(string)$sel['itemName'],'gender'=>(string)($sel['demographic']??''),'thumbs'=>(string)($sel['thumbnails_json']??''),'hero'=>(string)($sel['hero_image']??''),'chosen'=>(string)($sel['chosen_image']??''),'override'=>(string)($overrideById[(int)$sel['itemId']]??'')];$matched[(int)$sel['itemId']]=true;$thumbStatus=thumbsCompare($csvThumbs,$mysql['thumbs']);
+if($csvDbId!==''&&(int)$csvDbId===(int)$sel['itemId'])$notes[]='db_itemId agrees with matched MySQL itemId.'; if($csvDbId!==''&&(int)$csvDbId!==(int)$sel['itemId'])$notes[]='db_itemId differs from matched MySQL itemId (clue only).';
+$csvMissing=0; foreach(array_merge(parsePathList($csvImages),parseJsonArray($csvThumbs)) as $p){if(!pathExistsLocal($imagesRoot,$p))$csvMissing++;}
+$myMissing=0; foreach(array_merge(parseJsonArray($mysql['thumbs']),[$mysql['hero'],$mysql['chosen'],$mysql['override']]) as $p){if(trim($p)!==''&&!pathExistsLocal($imagesRoot,$p))$myMissing++;}
+if($csvMissing>0)$counts['rows where local files are missing for CSV paths']++; if($myMissing>0)$counts['rows where local files are missing for MySQL paths']++; $fs="csv_missing={$csvMissing};mysql_missing={$myMissing}";
+if(in_array($thumbStatus,['identical','same_set_different_order'],true)){$status='in_sync';$action='no_action';} else {$status='mysql_stale_relative_to_csv';$action='review_update_mysql_thumbnails_from_csv'; if(parseJsonArray($csvThumbs)&&$mysql['thumbs']!==$csvThumbs)$counts['rows where CSV thumbnails_json is nonblank and MySQL thumbnails_json differs']++;}}
+if(isset($counts[$status]))$counts[$status]++; if($status==='manual_review_required')$counts['manual_review_required']++; if($sel)$counts['matched rows']++;
+fputcsv($out,[$status,$conf,$rowNum,$csvDbId,$mysql['id'],$csvBrand,$mysql['brand'],$csvName,$mysql['name'],$csvGender,$mysql['gender'],$csvImages,$csvThumbs,$mysql['thumbs'],$thumbStatus,$csvVideos,$mysql['hero'],$mysql['chosen'],$mysql['override'],$heroStatus,$overrideStatus,$fs,$action,implode(' | ',array_merge($notes,['Never blind-overwrite item.hero_image, item.chosen_image, hero_override.chosen_image.']))]);
+}
+foreach($itemById as $id=>$it){if(isset($matched[$id]))continue; $counts['mysql_only_legacy']++; fputcsv($out,['mysql_only_legacy','medium','','',(string)$id,'',(string)$it['brand'],'',(string)$it['itemName'],'',(string)($it['demographic']??''),'','',(string)($it['thumbnails_json']??''),'manual_review_required','',(string)($it['hero_image']??''),(string)($it['chosen_image']??''),(string)($overrideById[$id]??''),'protected_fields_no_blind_overwrite',$hasOverride?'override_table_present':'override_table_missing','not_checked','manual_review_required','Present in MySQL but not matched from CSV rows.']);}
+fclose($in); fclose($out);
+$md=["# Image Sync Reconciliation Summary","","Generated: ".gmdate('Y-m-d H:i:s')." UTC","","## Counts"]; foreach($counts as $k=>$v){$md[]="- {$k}: {$v}";} $md[]=""; $md[]='This is a read-only analysis. No SQL writes/migrations/repairs were executed.'; file_put_contents($summaryPath,implode("\n",$md)."\n");
+echo "Report: {$reportPath}\nSummary: {$summaryPath}\n"; foreach($counts as $k=>$v) echo "{$k}: {$v}\n";


### PR DESCRIPTION
### Motivation
- Provide a local, read-only inspection tool to detect image-path/drift between `docs/data/SportWarehouse_ProductDB.csv` and the live MySQL `item` table (and `hero_override` when present) without performing any DB writes or destructive actions. 
- Make it safe to run in local dev environments (Laragon/DBeaver) and ensure protected runtime/editor fields are never blindly recommended for overwrite.

### Description
- Add a CLI-only script at `tools/reports/image-sync-reconciliation.php` that reads the CSV, queries `item` (and `hero_override` if present), and builds reconciliation rows written to `docs/operations/generated/image-sync-reconciliation-report.csv` and a short markdown summary at `docs/operations/generated/image-sync-reconciliation-summary.md`.
- Enforce read-only DB access via a guard `mustSelect()` and use `qAll()` wrapper for all queries so non-`SELECT` SQL is refused at runtime.
- Match rows primarily by normalized `brand + itemName` while treating `db_itemId` only as a confidence clue, and mark ambiguous/duplicate/uncertain matches as `ambiguous_match`/`manual_review_required` as appropriate.
- Compare `thumbnails_json` sets with detailed status vocabulary (`identical`, `same_set_different_order`, `csv_has_brands_path_mysql_legacy`, `csv_has_extra_path_segments`, `csv_different_folder_or_filename`, `csv_blank_mysql_nonblank`, `mysql_blank_csv_nonblank`, `both_blank`, `manual_review_required`), perform local filesystem existence checks where possible, and emit recommended action vocabulary while explicitly protecting `item.hero_image`, `item.chosen_image`, and `hero_override.chosen_image` from blind-overwrite recommendations.
- Provide usage notes at the top of the script for both `php tools/reports/image-sync-reconciliation.php` and the Windows/Laragon PHP executable path.

### Testing
- Ran `php -l tools/reports/image-sync-reconciliation.php` to validate PHP syntax; result: no syntax errors detected.
- Ran `git diff --check` to ensure no whitespace or diff issues; result: clean.
- The script is implemented as a read-only analysis and requires a local MySQL connection to produce runtime reports; no fake report output was generated during tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b00a207108324a5bec21b3dbdb374)