### PR TITLE
Fix PR #65 runtime schema mismatch in image-sync reconciliation script

### DIFF
--- a/tools/reports/image-sync-reconciliation.php
+++ b/tools/reports/image-sync-reconciliation.php
@@ -20,12 +20,40 @@ $counts = ['total CSV rows'=>0,'total active MySQL items considered'=>0,'matched
 function mustSelect(string $sql): void { if (!preg_match('/^SELECT\b/i', ltrim($sql))) throw new RuntimeException('Refusing non-SELECT SQL.'); }
 function qAll(PDO $pdo, string $sql, array $params=[]): array { mustSelect($sql); $s=$pdo->prepare($sql); $s->execute($params); return $s->fetchAll(PDO::FETCH_ASSOC);} 
 function norm(?string $v): string { return preg_replace('/[^a-z0-9]+/', '', strtolower(trim((string)$v))) ?? ''; }
+function tableColumns(PDO $pdo, string $table): array {
+    $rows = qAll($pdo, "SELECT COLUMN_NAME FROM information_schema.columns WHERE table_schema=DATABASE() AND table_name=:t", ['t'=>$table]);
+    return array_values(array_map(static fn($r)=>(string)$r['COLUMN_NAME'], $rows));
+}
 function parsePathList(?string $v): array { $v=trim((string)$v); if($v==='') return []; return array_values(array_filter(array_map('trim', preg_split('/\s*,\s*/',$v) ?: []), fn($x)=>$x!=='')); }
 function parseJsonArray(?string $v): array { $v=trim((string)$v); if($v==='') return []; $d=json_decode($v,true); if(!is_array($d)) return []; return array_values(array_filter(array_map(fn($x)=>trim((string)$x),$d),fn($x)=>$x!=='')); }
 function pathExistsLocal(string $imagesRoot, string $path): bool { $p=ltrim(str_replace('\\','/',trim($path)),'/'); if($p==='') return true; if(str_starts_with($p,'images/')) return is_file(dirname($imagesRoot).'/'.$p); return is_file($imagesRoot.'/'.$p); }
 function thumbsCompare(string $csv, string $mysql): string { $c=parseJsonArray($csv); $m=parseJsonArray($mysql); if(!$c&&!$m) return 'both_blank'; if(!$c&&$m) return 'csv_blank_mysql_nonblank'; if($c&&!$m) return 'mysql_blank_csv_nonblank'; if($c===$m) return 'identical'; $a=$c;$b=$m;sort($a);sort($b); if($a===$b) return 'same_set_different_order'; if(count(array_filter($c,fn($p)=>str_contains($p,'/brands/')))>0&&count(array_filter($m,fn($p)=>!str_contains($p,'/brands/')))>0) return 'csv_has_brands_path_mysql_legacy'; if(count(array_filter($c,fn($p)=>substr_count($p,'/')>=3))>0) return 'csv_has_extra_path_segments'; return 'csv_different_folder_or_filename'; }
 require $root . '/db.php';
-$items=qAll($pdo,"SELECT itemId, brand, itemName, demographic, thumbnails_json, hero_image, chosen_image FROM item");
+$itemCols = tableColumns($pdo, 'item');
+$itemColsSet = array_fill_keys($itemCols, true);
+$preferredDemographicCols = ['gender','age_group','size_type','demographic'];
+$chosenDemographicCol = '';
+foreach ($preferredDemographicCols as $c) {
+    if (isset($itemColsSet[$c])) { $chosenDemographicCol = $c; break; }
+}
+$optionalItemCols = ['categoryName','subcategory','hero_image','thumbnails_json','chosen_image','is_active'];
+$missingOptionalCols = [];
+foreach (array_merge($optionalItemCols, $preferredDemographicCols) as $c) {
+    if (!isset($itemColsSet[$c])) $missingOptionalCols[] = $c;
+}
+$selectExpr = [
+    'itemId',
+    'brand',
+    'itemName',
+    ($chosenDemographicCol !== '' ? $chosenDemographicCol : 'NULL') . ' AS mysql_gender_or_demographic',
+    (isset($itemColsSet['thumbnails_json']) ? 'thumbnails_json' : 'NULL') . ' AS thumbnails_json',
+    (isset($itemColsSet['hero_image']) ? 'hero_image' : 'NULL') . ' AS hero_image',
+    (isset($itemColsSet['chosen_image']) ? 'chosen_image' : 'NULL') . ' AS chosen_image',
+    (isset($itemColsSet['categoryName']) ? 'categoryName' : 'NULL') . ' AS categoryName',
+    (isset($itemColsSet['subcategory']) ? 'subcategory' : 'NULL') . ' AS subcategory',
+    (isset($itemColsSet['is_active']) ? 'is_active' : 'NULL') . ' AS is_active',
+];
+$items=qAll($pdo,"SELECT ".implode(', ', $selectExpr)." FROM item");
 $counts['total active MySQL items considered']=count($items);
 $hasOverride=(int)(qAll($pdo,"SELECT COUNT(*) c FROM information_schema.tables WHERE table_schema=DATABASE() AND table_name='hero_override'")[0]['c']??0)>0;
 $overrideById=[]; if($hasOverride){ foreach(qAll($pdo,"SELECT itemId, chosen_image FROM hero_override") as $r){$overrideById[(int)$r['itemId']]=(string)($r['chosen_image']??'');}}
@@ -37,7 +65,7 @@ $csvBrand=$get('brand');$csvName=$get('itemName');$csvDbId=$get('db_itemId');$cs
 $cands=$index[norm($csvBrand).'|'.norm($csvName)]??[]; $sel=null;$status='manual_review_required';$conf='low';$notes=[];
 if(count($cands)===1){$sel=$cands[0];$conf='high';} elseif(count($cands)>1){$status='ambiguous_match';$counts['ambiguous_match']++;$notes[]='Multiple MySQL rows match normalized brand+itemName.';} else {$status=$csvDbId===''?'csv_future_or_staging':'csv_only_candidate';$counts[$status]++;$conf=$csvDbId===''?'medium':'low';$notes[]='No MySQL match by normalized brand+itemName.';}
 $mysql=['id'=>'','brand'=>'','name'=>'','gender'=>'','thumbs'=>'','hero'=>'','chosen'=>'','override'=>''];$heroStatus='protected_fields_no_blind_overwrite';$overrideStatus=$hasOverride?'override_table_present':'override_table_missing';$thumbStatus='manual_review_required';$fs='not_checked';$action='manual_review_required';
-if($sel){$mysql=['id'=>(string)$sel['itemId'],'brand'=>(string)$sel['brand'],'name'=>(string)$sel['itemName'],'gender'=>(string)($sel['demographic']??''),'thumbs'=>(string)($sel['thumbnails_json']??''),'hero'=>(string)($sel['hero_image']??''),'chosen'=>(string)($sel['chosen_image']??''),'override'=>(string)($overrideById[(int)$sel['itemId']]??'')];$matched[(int)$sel['itemId']]=true;$thumbStatus=thumbsCompare($csvThumbs,$mysql['thumbs']);
+if($sel){$mysql=['id'=>(string)$sel['itemId'],'brand'=>(string)$sel['brand'],'name'=>(string)$sel['itemName'],'gender'=>(string)($sel['mysql_gender_or_demographic']??''),'thumbs'=>(string)($sel['thumbnails_json']??''),'hero'=>(string)($sel['hero_image']??''),'chosen'=>(string)($sel['chosen_image']??''),'override'=>(string)($overrideById[(int)$sel['itemId']]??'')];$matched[(int)$sel['itemId']]=true;$thumbStatus=thumbsCompare($csvThumbs,$mysql['thumbs']);
 if($csvDbId!==''&&(int)$csvDbId===(int)$sel['itemId'])$notes[]='db_itemId agrees with matched MySQL itemId.'; if($csvDbId!==''&&(int)$csvDbId!==(int)$sel['itemId'])$notes[]='db_itemId differs from matched MySQL itemId (clue only).';
 $csvMissing=0; foreach(array_merge(parsePathList($csvImages),parseJsonArray($csvThumbs)) as $p){if(!pathExistsLocal($imagesRoot,$p))$csvMissing++;}
 $myMissing=0; foreach(array_merge(parseJsonArray($mysql['thumbs']),[$mysql['hero'],$mysql['chosen'],$mysql['override']]) as $p){if(trim($p)!==''&&!pathExistsLocal($imagesRoot,$p))$myMissing++;}
@@ -46,7 +74,11 @@ if(in_array($thumbStatus,['identical','same_set_different_order'],true)){$status
 if(isset($counts[$status]))$counts[$status]++; if($status==='manual_review_required')$counts['manual_review_required']++; if($sel)$counts['matched rows']++;
 fputcsv($out,[$status,$conf,$rowNum,$csvDbId,$mysql['id'],$csvBrand,$mysql['brand'],$csvName,$mysql['name'],$csvGender,$mysql['gender'],$csvImages,$csvThumbs,$mysql['thumbs'],$thumbStatus,$csvVideos,$mysql['hero'],$mysql['chosen'],$mysql['override'],$heroStatus,$overrideStatus,$fs,$action,implode(' | ',array_merge($notes,['Never blind-overwrite item.hero_image, item.chosen_image, hero_override.chosen_image.']))]);
 }
-foreach($itemById as $id=>$it){if(isset($matched[$id]))continue; $counts['mysql_only_legacy']++; fputcsv($out,['mysql_only_legacy','medium','','',(string)$id,'',(string)$it['brand'],'',(string)$it['itemName'],'',(string)($it['demographic']??''),'','',(string)($it['thumbnails_json']??''),'manual_review_required','',(string)($it['hero_image']??''),(string)($it['chosen_image']??''),(string)($overrideById[$id]??''),'protected_fields_no_blind_overwrite',$hasOverride?'override_table_present':'override_table_missing','not_checked','manual_review_required','Present in MySQL but not matched from CSV rows.']);}
+foreach($itemById as $id=>$it){if(isset($matched[$id]))continue; $counts['mysql_only_legacy']++; fputcsv($out,['mysql_only_legacy','medium','','',(string)$id,'',(string)$it['brand'],'',(string)$it['itemName'],'',(string)($it['mysql_gender_or_demographic']??''),'','',(string)($it['thumbnails_json']??''),'manual_review_required','',(string)($it['hero_image']??''),(string)($it['chosen_image']??''),(string)($overrideById[$id]??''),'protected_fields_no_blind_overwrite',$hasOverride?'override_table_present':'override_table_missing','not_checked','manual_review_required','Present in MySQL but not matched from CSV rows.']);}
 fclose($in); fclose($out);
-$md=["# Image Sync Reconciliation Summary","","Generated: ".gmdate('Y-m-d H:i:s')." UTC","","## Counts"]; foreach($counts as $k=>$v){$md[]="- {$k}: {$v}";} $md[]=""; $md[]='This is a read-only analysis. No SQL writes/migrations/repairs were executed.'; file_put_contents($summaryPath,implode("\n",$md)."\n");
+$runtimeNotes = [];
+if ($chosenDemographicCol === '') $runtimeNotes[] = "No demographic/report source column available; mysql_gender_or_demographic emitted as blank.";
+else $runtimeNotes[] = "Demographic/report source column selected from item table: {$chosenDemographicCol}.";
+if ($missingOptionalCols) $runtimeNotes[] = 'Missing optional item columns detected at runtime: ' . implode(', ', $missingOptionalCols) . '.';
+$md=["# Image Sync Reconciliation Summary","","Generated: ".gmdate('Y-m-d H:i:s')." UTC","","## Counts"]; foreach($counts as $k=>$v){$md[]="- {$k}: {$v}";} $md[]=""; $md[]="## Runtime schema notes"; foreach($runtimeNotes as $n){$md[]="- {$n}";} $md[]=""; $md[]='This is a read-only analysis. No SQL writes/migrations/repairs were executed.'; file_put_contents($summaryPath,implode("\n",$md)."\n");
 echo "Report: {$reportPath}\nSummary: {$summaryPath}\n"; foreach($counts as $k=>$v) echo "{$k}: {$v}\n";


### PR DESCRIPTION
### Motivation
- Prevent the `Unknown column 'demographic' in 'field list'` failure by making the reconciliation script robust to differing `item` table schemas at runtime.
- Keep the script strictly read-only and avoid adding any DB writes, migrations, or repair SQL while preserving existing report column stability.

### Description
- Added `tableColumns(PDO $pdo, string $table)` to inspect `information_schema.columns` and build a safe projection using only columns that exist on `item` in `tools/reports/image-sync-reconciliation.php`.
- Implemented demographic/report source fallback order `gender` → `age_group` → `size_type` → `demographic` and emit the chosen value as `mysql_gender_or_demographic`, or `NULL` when none are present to keep the report columns stable.
- Project optional fields (`categoryName`, `subcategory`, `hero_image`, `thumbnails_json`, `chosen_image`, `is_active`) defensively as either the real column or `NULL` to avoid SELECT failures on schemas missing those columns.
- Added runtime schema notes into the generated summary to report the chosen demographic column and any missing optional columns while preserving the `mustSelect` SELECT-only safeguard.

### Testing
- Ran `php -l tools/reports/image-sync-reconciliation.php` and it reported no syntax errors.
- Ran `git diff --check` and it reported no problems.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b02fa161c832483efecc142050f76)