### PR TITLE
Add CSV-as-source-of-truth MySQL alignment plan and audit

### DIFF
--- a/README/V-AUDIT/POST-AUDIT/2026-05-18-CSV-Source-of-Truth-MySQL-Alignment-Plan.md
+++ b/README/V-AUDIT/POST-AUDIT/2026-05-18-CSV-Source-of-Truth-MySQL-Alignment-Plan.md
@@ -1,0 +1,123 @@
+# CSV-as-Source-of-Truth MySQL Alignment Plan (No-Write)
+
+## Scope and constraints
+- **Objective:** plan structural and data alignment so MySQL `item` aligns to the Excel-derived CSV as the source of truth.
+- **No-write guardrails honored:** no DB writes, no migrations executed, no repair SQL run, no hero/image behavior changes.
+- **Identity direction:** `model_id` is treated as the proposed long-term catalogue identity; `db_itemId` is treated only as legacy back-reference.
+
+## Inputs reviewed
+- CSV source: `docs/data/SportWarehouse_ProductDB.csv`
+- MySQL snapshot schema/data: `db/sportswh_dump_sanitized.sql` (`item` DDL + INSERT snapshot)
+- Identity contract context: `README/II-CONTRACTS/19-Model_ID_Generation_&_Identity_Governance_Contract.md`
+
+## 1) CSV columns vs MySQL `item` columns
+
+### CSV columns (45)
+`brand, gender, itemName, itemName_fully_derived, model_id, product_domain, collection, model_family, subCategory, fabric, construction, seamless, scrunchFlag, invisibleFlag, neckline, strap_configuration, support_level, rise, length, variant, usage_category, usage_subtype, categoryName, parentCategory, ageGroup, sizeType, fitStyle, activityTags, price, salePrice, description, featured, images, thumbnails_json, external_item_id, campaign_or_series, altText, ariaText, videoAltText, videos, images2, CropAllowed, db_itemId, assignment_source, _images_helper_normalize`
+
+### MySQL `item` columns in snapshot (24)
+`itemId, itemName, brand, gender, subcategory, price, salePrice, description, featured, categoryId, categoryName, parentCategory, activity_tags, age_group, size_type, fit_style, images, orientation, thumbnails_json, altText, ariaText, videoAltText, videos`
+
+> Note: `subCategory` vs `subcategory`, `activityTags` vs `activity_tags`, `ageGroup` vs `age_group`, `sizeType` vs `size_type`, `fitStyle` vs `fit_style` are semantic matches but naming-drifted.
+
+## 2) CSV columns missing from MySQL `item` (schema alignment candidates)
+30 CSV columns are absent in current `item` schema:
+
+- `itemName_fully_derived`
+- `model_id`
+- `product_domain`
+- `collection`
+- `model_family`
+- `subCategory` (case/shape mismatch vs `subcategory`)
+- `fabric`
+- `construction`
+- `seamless`
+- `scrunchFlag`
+- `invisibleFlag`
+- `neckline`
+- `strap_configuration`
+- `support_level`
+- `rise`
+- `length`
+- `variant`
+- `usage_category`
+- `usage_subtype`
+- `ageGroup` (shape mismatch vs `age_group`)
+- `sizeType` (shape mismatch vs `size_type`)
+- `fitStyle` (shape mismatch vs `fit_style`)
+- `activityTags` (shape mismatch vs `activity_tags`)
+- `external_item_id`
+- `campaign_or_series`
+- `images2`
+- `CropAllowed`
+- `db_itemId`
+- `assignment_source`
+- `_images_helper_normalize`
+
+## 3) `model_id` as new identity (with validation)
+- `model_id` is present on every CSV row and should be promoted to canonical identity candidate.
+- Before adoption, enforce validation gates:
+  1. nonblank required,
+  2. uniqueness required,
+  3. normalization consistency (trim/lower/slug policy),
+  4. immutability governance post-publication.
+
+## 4) `model_id` audit
+- Total CSV rows: **120**
+- Nonblank `model_id`: **120**
+- Blank `model_id`: **0**
+- Duplicate `model_id` values: **1 value duplicated**
+  - `nike_female_leggings` appears **2** times
+
+## 5) `db_itemId` audit (legacy back-reference only)
+- CSV rows with populated `db_itemId`: **54 distinct IDs referenced**.
+- Legacy mapping should be used only for transitional reconciliation and rollback traceability.
+- Do **not** elevate `db_itemId` to long-term identity.
+
+## 6) Row classification (planning-grade)
+Using CSV + MySQL snapshot (`db/sportswh_dump_sanitized.sql`) with `db_itemId` and name-delta checks:
+
+- **Existing MySQL products mapped confidently:** **15**
+  - (`db_itemId` present in snapshot and `itemName` unchanged)
+- **Renamed products requiring manual mapping review:** **33**
+  - (`db_itemId` present in snapshot but `itemName` changed)
+- **New CSV products not yet in MySQL snapshot:** **72**
+  - (`db_itemId` blank or not found in snapshot)
+- **Old MySQL products no longer represented in CSV:** **0** in this snapshot comparison
+
+Interpretation:
+- High rename count confirms why normalized `brand + itemName` is unsafe as identity.
+- Review queue should be keyed on `model_id`, then adjudicated by legacy `db_itemId`, then human review where collisions/ambiguities remain.
+
+## 7) Recommended alignment approach
+Yes—proceed with a staged, reviewable workflow:
+
+1. **Schema alignment prep (design only now):**
+   - Add missing authoritative CSV columns to MySQL (or a parallel catalog table) so CSV semantics can land losslessly.
+   - Add `model_id` column with planned unique index after duplicate cleanup.
+2. **Create CSV staging table:**
+   - `item_staging_csv` mirroring CSV headers (including helper/trace columns).
+   - Load raw CSV into staging unchanged.
+3. **Reviewed import/update pipeline:**
+   - Validation phase (required/enum/type/nullability + duplicate `model_id` stop condition).
+   - Match phase in priority order: `model_id` -> `db_itemId` -> manual queue.
+   - Action phase: INSERT new, UPDATE matched, flag unresolved for review.
+   - Produce dry-run diff artifacts before any write execution.
+4. **Cutover rule:**
+   - Treat staging+review outputs as gate; only then schedule controlled SQL migration/import.
+
+## 8) Runtime/editor-managed fields to preserve
+During future alignment execution, explicitly preserve operational image overrides and runtime-managed selections:
+
+- `item.hero_image`
+- `item.chosen_image`
+- `hero_override.chosen_image`
+
+Practical rule for future implementation:
+- Do not overwrite these fields from CSV import paths unless a dedicated override workflow explicitly authorizes it.
+
+## Proposed next steps (still plan-only)
+1. Draft target DDL (not executed) for missing columns and index strategy (`model_id` unique after duplicate resolution).
+2. Draft staging table DDL and CSV load spec (no run).
+3. Draft dry-run reconciliation SQL/report queries for the four classes above.
+4. Resolve duplicate `model_id` (`nike_female_leggings`) in source CSV governance before any unique constraint rollout.


### PR DESCRIPTION
### Motivation
- The Excel-derived CSV is now the authoritative product database and MySQL must be aligned structurally and data-wise without destructive changes. 
- Promote the CSV `model_id` as the likely canonical catalogue identity while treating `db_itemId` only as a legacy back-reference for reconciliation. 
- Identify schema gaps and provide a safe, reviewed migration/import workflow that preserves runtime/editor-managed image fields. 

### Description
- Added a planning/audit document `README/V-AUDIT/POST-AUDIT/2026-05-18-CSV-Source-of-Truth-MySQL-Alignment-Plan.md` that compares CSV headers to the current MySQL `item` schema and enumerates mismatches and naming-drift. 
- Listed 30 CSV columns missing from the snapshot `item` table (including `model_id`, `itemName_fully_derived`, product and model taxonomy fields, image helpers, and `db_itemId`). 
- Performed a `model_id` audit (total rows 120; nonblank 120; blank 0; one duplicated `model_id` value `nike_female_leggings`) and classified rows into confident mappings (15), renamed requiring review (33), new CSV products (72), and old-MySQL-only (0) for this snapshot. 
- Recommended a staged alignment: design schema additions (or parallel catalog table), create a CSV-mirroring staging table, run validation/match/dry-run reconciliation (priority `model_id` → `db_itemId` → manual), and preserve `item.hero_image`, `item.chosen_image`, and `hero_override.chosen_image` from CSV overwrites. 

### Testing
- Ran CSV/schema analysis using the ad-hoc Python inspection that parsed `docs/data/SportWarehouse_ProductDB.csv` and `db/sportswh_dump_sanitized.sql` to produce the column comparison, `model_id` audit, and classification counts, and the script completed successfully (`python - <<'PY'` analysis). 
- Verified the CSV file discovery (`rg --files -g "*.csv"`) and that `docs/data/SportWarehouse_ProductDB.csv` was read with `utf-8-sig` without errors. 
- Confirmed the planning document file was created at `README/V-AUDIT/POST-AUDIT/2026-05-18-CSV-Source-of-Truth-MySQL-Alignment-Plan.md` and contains the audit outputs; no database writes, migrations, or repair SQL were executed during testing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b12e6d5ec83249cf4d8aaca0ba2c1)