### PR TITLE
docs: refine CSV/MySQL alignment plan terminology

### DIFF
--- a/README/V-AUDIT/POST-AUDIT/2026-05-18-CSV-Source-of-Truth-MySQL-Alignment-Plan.md
+++ b/README/V-AUDIT/POST-AUDIT/2026-05-18-CSV-Source-of-Truth-MySQL-Alignment-Plan.md
@@ -12,8 +12,8 @@
 
 ### Live local reconciliation input (DBeaver/MySQL CLI report)
 - Reconciliation source: local DBeaver/MySQL report output (`tools/reports/image-sync-reconciliation.php` logic + local database state).
-- Reported buckets in the live run: matched rows **46**, `csv_future_or_staging` **66**, `csv_only_candidate` **8**, `mysql_only_legacy` **16`.
-- Live MySQL includes legacy `db_itemId` usage in reconciliation context.
+- Reported buckets in the live run: matched rows **46**, `csv_future_or_staging` **66**, `csv_only_candidate` **8**, `mysql_only_legacy` **16**.
+- Live MySQL includes a `db_itemId` column, and `db_itemId` is the intended database linkage field where populated in reconciliation context.
 
 ### Scope note on source freshness
 - The sanitized dump is a repository snapshot for planning and may be older than, or otherwise different from, the current live local DBeaver/MySQL schema and row state.
@@ -32,7 +32,7 @@
 > Note: `subCategory` vs `subcategory`, `activityTags` vs `activity_tags`, `ageGroup` vs `age_group`, `sizeType` vs `size_type`, `fitStyle` vs `fit_style` are semantic matches but naming-drifted.
 
 ## 2) CSV columns missing from MySQL `item` (schema alignment candidates)
-30 CSV columns are absent in current `item` schema:
+30 CSV columns are absent from the repository snapshot `item` schema:
 
 - `itemName_fully_derived`
 - `model_id`
@@ -65,8 +65,8 @@
 - `assignment_source`
 - `_images_helper_normalize`
 
-## 3) `model_id` as new identity (with validation)
-- `model_id` is present on every CSV row and should be promoted to canonical identity candidate.
+## 3) `model_id` as formula-derived catalogue fingerprint (with validation)
+- `model_id` is present on every CSV row and should be treated as a formula-derived catalogue fingerprint used for validation, duplicate detection, and stable product classification (not a numeric database ID).
 - Before adoption, enforce validation gates:
   1. nonblank required,
   2. uniqueness required,


### PR DESCRIPTION
### Motivation
- Clarify terminology and correct a small Markdown typo in the CSV-as-source-of-truth MySQL alignment plan so guidance around `db_itemId`, `model_id`, and snapshot wording is precise and unambiguous.

### Description
- Fixed the Markdown typo so the live reconciliation bucket shows `` `mysql_only_legacy` **16** `` correctly in `README/V-AUDIT/POST-AUDIT/2026-05-18-CSV-Source-of-Truth-MySQL-Alignment-Plan.md`.
- Reworded the `db_itemId` reconciliation line to state live MySQL includes a `db_itemId` column and that `db_itemId` is the intended database linkage field where populated, removing the legacy phrasing.
- Renamed the `model_id` section heading to "model_id as formula-derived catalogue fingerprint" and clarified that `model_id` is a formula-derived fingerprint used for validation, duplicate detection, and stable product classification (not a numeric database ID).
- Clarified snapshot language by changing phrasing to reference the repository snapshot `item` schema (e.g., "absent from the repository snapshot `item` schema").

### Testing
- Ran the automated in-repo edit (`python` replacement), reviewed the resulting diff with `git diff -- README/V-AUDIT/POST-AUDIT/2026-05-18-CSV-Source-of-Truth-MySQL-Alignment-Plan.md`, and inspected the updated file with `sed`/`nl`; all verification steps completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b1978a2ac8324be9f37ca5c084b5d)