### PR TITLE
Add read-only db_itemId/model_id readiness audit generator

### DIFF
--- a/docs/operations/generated/2026-05-18-db_itemid-model_id-readiness-audit.md
+++ b/docs/operations/generated/2026-05-18-db_itemid-model_id-readiness-audit.md
@@ -1,0 +1,45 @@
+# db_itemId/model_id Readiness Audit (Read-Only)
+
+- Generated: 2026-05-18 14:01:29 UTC
+- Source CSV: `docs/data/SportWarehouse_ProductDB.csv`
+- Scope: read-only audit (CSV + SELECT-only MySQL checks)
+- DB status: connection failed (`SQLSTATE[HY000] [2002] Connection refused`)
+
+## 1) CSV db_itemId audit
+- Total CSV rows: **120**
+- Rows with nonblank db_itemId: **54**
+- Rows with blank db_itemId: **66**
+- Duplicate nonblank db_itemId values: **0**
+- First 20 nonblank db_itemId values: `1`, `2`, `3`, `4`, `5`, `6`, `7`, `8`, `9`, `10`, `11`, `12`, `13`, `14`, `15`, `16`, `17`, `18`, `19`, `20`
+
+## 2) Live MySQL item audit
+- Total active item rows: **0** (no `active` column; all rows counted)
+- item.db_itemId exists: **no**
+- Rows with nonblank item.db_itemId: **0**
+- Rows with blank item.db_itemId: **0**
+- Duplicate nonblank item.db_itemId values: **0**
+- First 20 nonblank item.db_itemId values: ``
+- First 20 itemId values: ``
+
+## 3) Cross-check
+- CSV db_itemId values matching MySQL itemId: **0**
+- CSV db_itemId values matching MySQL db_itemId: **0**
+- CSV db_itemId values not found in MySQL: **54**
+- MySQL itemId/db_itemId values not represented in CSV: **0**
+
+## 4) model_id audit
+- Total CSV rows: **120**
+- Nonblank model_id rows: **120**
+- Blank model_id rows: **0**
+- Duplicate model_id values: **1**
+- Duplicate model_id list:
+  - `nike_female_leggings` × 2
+
+## 5) Classification
+- Existing rows confidently linked by db_itemId: **0**
+- Likely new insert candidates (blank db_itemId + unique nonblank model_id): **66**
+- Rows requiring manual mapping: **54**
+
+## Appendix (samples)
+- Sample CSV db_itemId not found in MySQL (first 20): `1`, `2`, `3`, `4`, `5`, `6`, `7`, `8`, `9`, `10`, `11`, `12`, `13`, `14`, `15`, `16`, `17`, `18`, `19`, `20`
+- Sample MySQL values not in CSV (first 20): ``

--- a/tools/reports/generate_db_itemid_modelid_readiness_audit.php
+++ b/tools/reports/generate_db_itemid_modelid_readiness_audit.php
@@ -1,0 +1,219 @@
+<?php
+require_once __DIR__ . '/../../inc/env.php';
+
+$csvPath = __DIR__ . '/../../docs/data/SportWarehouse_ProductDB.csv';
+$outDir = __DIR__ . '/../../docs/operations/generated';
+$outPath = $outDir . '/2026-05-18-db_itemid-model_id-readiness-audit.md';
+
+if (!is_readable($csvPath)) {
+    fwrite(STDERR, "CSV not readable: {$csvPath}\n");
+    exit(1);
+}
+
+if (!is_dir($outDir) && !mkdir($outDir, 0775, true) && !is_dir($outDir)) {
+    fwrite(STDERR, "Unable to create output directory: {$outDir}\n");
+    exit(1);
+}
+
+function norm(?string $v): string {
+    return trim((string)$v);
+}
+
+$fh = fopen($csvPath, 'r');
+$headers = fgetcsv($fh);
+if ($headers === false) {
+    fwrite(STDERR, "Failed to read CSV header.\n");
+    exit(1);
+}
+
+$idx = array_flip($headers);
+foreach (['db_itemId','model_id','itemName'] as $required) {
+    if (!isset($idx[$required])) {
+        fwrite(STDERR, "Missing required CSV column: {$required}\n");
+        exit(1);
+    }
+}
+
+$totalCsvRows = 0;
+$csvDbNonblank = [];
+$csvDbBlank = 0;
+$csvModelNonblank = [];
+$csvModelBlank = 0;
+
+while (($row = fgetcsv($fh)) !== false) {
+    $totalCsvRows++;
+    $dbItemId = norm($row[$idx['db_itemId']] ?? '');
+    $modelId = norm($row[$idx['model_id']] ?? '');
+
+    if ($dbItemId === '') {
+        $csvDbBlank++;
+    } else {
+        $csvDbNonblank[] = $dbItemId;
+    }
+
+    if ($modelId === '') {
+        $csvModelBlank++;
+    } else {
+        $csvModelNonblank[] = $modelId;
+    }
+}
+fclose($fh);
+
+$csvDbCounts = array_count_values($csvDbNonblank);
+$csvDbDupes = array_filter($csvDbCounts, fn($c) => $c > 1);
+ksort($csvDbDupes, SORT_NATURAL);
+
+$csvModelCounts = array_count_values($csvModelNonblank);
+$csvModelDupes = array_filter($csvModelCounts, fn($c) => $c > 1);
+ksort($csvModelDupes, SORT_NATURAL);
+
+$dbHost = sw_env('DB_HOST', '127.0.0.1');
+$dbName = sw_env('DB_NAME', 'sportswh');
+$dbUser = sw_env('DB_USER', 'root');
+$dbPass = sw_env('DB_PASS', '');
+
+$dbError = null;
+$hasActive = false;
+$hasDbItemId = false;
+$totalActive = 0;
+$itemIds = [];
+
+try {
+    $pdo = new PDO(
+        "mysql:host={$dbHost};dbname={$dbName};charset=utf8mb4",
+        $dbUser,
+        $dbPass,
+        [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION]
+    );
+
+    $hasActive = (bool)$pdo->query("SHOW COLUMNS FROM item LIKE 'active'")->fetch(PDO::FETCH_ASSOC);
+    $hasDbItemId = (bool)$pdo->query("SHOW COLUMNS FROM item LIKE 'db_itemId'")->fetch(PDO::FETCH_ASSOC);
+    $activeWhere = $hasActive ? 'WHERE active = 1' : '';
+
+    $totalActive = (int)$pdo->query("SELECT COUNT(*) FROM item {$activeWhere}")->fetchColumn();
+    $itemIds = $pdo->query("SELECT itemId FROM item {$activeWhere} ORDER BY itemId ASC")->fetchAll(PDO::FETCH_COLUMN);
+} catch (Throwable $e) {
+    $dbError = $e->getMessage();
+    $activeWhere = '';
+}
+
+$itemDbValues = [];
+$itemDbNonblankCount = 0;
+$itemDbBlankCount = $totalActive;
+$itemDbDupes = [];
+
+if ($hasDbItemId) {
+    $itemDbValues = $pdo->query("SELECT TRIM(COALESCE(db_itemId,'')) AS db_itemId FROM item {$activeWhere} ORDER BY itemId ASC")
+        ->fetchAll(PDO::FETCH_COLUMN);
+    $itemDbNonblank = array_values(array_filter($itemDbValues, fn($v) => $v !== ''));
+    $itemDbNonblankCount = count($itemDbNonblank);
+    $itemDbBlankCount = $totalActive - $itemDbNonblankCount;
+    $tmp = array_count_values($itemDbNonblank);
+    $itemDbDupes = array_filter($tmp, fn($c) => $c > 1);
+    ksort($itemDbDupes, SORT_NATURAL);
+}
+
+$csvDbUnique = array_values(array_unique($csvDbNonblank));
+$csvSet = array_fill_keys($csvDbUnique, true);
+$itemIdSet = array_fill_keys(array_map('strval', $itemIds), true);
+$itemDbSet = $hasDbItemId ? array_fill_keys(array_values(array_unique(array_filter($itemDbValues, fn($v)=>$v!==''))), true) : [];
+
+$csvMatchesItemId = [];
+$csvMatchesDbItemId = [];
+$csvNotFound = [];
+foreach ($csvDbUnique as $v) {
+    $hitItem = isset($itemIdSet[$v]);
+    $hitDb = $hasDbItemId && isset($itemDbSet[$v]);
+    if ($hitItem) $csvMatchesItemId[] = $v;
+    if ($hitDb) $csvMatchesDbItemId[] = $v;
+    if (!$hitItem && !$hitDb) $csvNotFound[] = $v;
+}
+
+$mysqlUnrepresented = [];
+foreach (array_keys($itemIdSet) as $id) {
+    if (!isset($csvSet[$id])) $mysqlUnrepresented[] = "itemId:{$id}";
+}
+if ($hasDbItemId) {
+    foreach (array_keys($itemDbSet) as $id) {
+        if (!isset($csvSet[$id])) $mysqlUnrepresented[] = "db_itemId:{$id}";
+    }
+}
+
+$linkedByDb = count($csvMatchesItemId) + count(array_diff($csvMatchesDbItemId, $csvMatchesItemId));
+$uniqueModelSet = array_filter($csvModelCounts, fn($c)=>$c===1);
+$insertCandidates = 0;
+$manualMapping = 0;
+
+$fh = fopen($csvPath, 'r');
+$headers = fgetcsv($fh);
+while (($row = fgetcsv($fh)) !== false) {
+    $dbItemId = norm($row[$idx['db_itemId']] ?? '');
+    $modelId = norm($row[$idx['model_id']] ?? '');
+    $needsManual = false;
+    if ($dbItemId !== '' && !isset($itemIdSet[$dbItemId]) && !($hasDbItemId && isset($itemDbSet[$dbItemId]))) {
+        $needsManual = true;
+    }
+    if ($modelId !== '' && (($csvModelCounts[$modelId] ?? 0) > 1)) {
+        $needsManual = true;
+    }
+    if ($needsManual) {
+        $manualMapping++;
+    } elseif ($dbItemId === '' && $modelId !== '' && isset($uniqueModelSet[$modelId])) {
+        $insertCandidates++;
+    }
+}
+fclose($fh);
+
+$md = [];
+$md[] = '# db_itemId/model_id Readiness Audit (Read-Only)';
+$md[] = '';
+$md[] = '- Generated: ' . gmdate('Y-m-d H:i:s') . ' UTC';
+$md[] = '- Source CSV: `docs/data/SportWarehouse_ProductDB.csv`';
+$md[] = '- Scope: read-only audit (CSV + SELECT-only MySQL checks)';
+if ($dbError !== null) {
+    $md[] = '- DB status: connection failed (`' . str_replace('`', '\\`', $dbError) . '`)';
+}
+$md[] = '';
+$md[] = '## 1) CSV db_itemId audit';
+$md[] = "- Total CSV rows: **{$totalCsvRows}**";
+$md[] = "- Rows with nonblank db_itemId: **" . count($csvDbNonblank) . "**";
+$md[] = "- Rows with blank db_itemId: **{$csvDbBlank}**";
+$md[] = "- Duplicate nonblank db_itemId values: **" . count($csvDbDupes) . "**";
+$md[] = '- First 20 nonblank db_itemId values: `' . implode('`, `', array_slice($csvDbNonblank, 0, 20)) . '`';
+$md[] = '';
+$md[] = '## 2) Live MySQL item audit';
+$md[] = "- Total active item rows: **{$totalActive}**" . ($hasActive ? ' (`active=1`)' : ' (no `active` column; all rows counted)');
+$md[] = "- item.db_itemId exists: **" . ($hasDbItemId ? 'yes' : 'no') . '**';
+$md[] = "- Rows with nonblank item.db_itemId: **{$itemDbNonblankCount}**";
+$md[] = "- Rows with blank item.db_itemId: **{$itemDbBlankCount}**";
+$md[] = "- Duplicate nonblank item.db_itemId values: **" . count($itemDbDupes) . "**";
+$md[] = '- First 20 nonblank item.db_itemId values: `' . implode('`, `', array_slice(array_values(array_filter($itemDbValues, fn($v)=>$v!=='')), 0, 20)) . '`';
+$md[] = '- First 20 itemId values: `' . implode('`, `', array_slice(array_map('strval', $itemIds), 0, 20)) . '`';
+$md[] = '';
+$md[] = '## 3) Cross-check';
+$md[] = '- CSV db_itemId values matching MySQL itemId: **' . count($csvMatchesItemId) . '**';
+$md[] = '- CSV db_itemId values matching MySQL db_itemId: **' . count($csvMatchesDbItemId) . '**';
+$md[] = '- CSV db_itemId values not found in MySQL: **' . count($csvNotFound) . '**';
+$md[] = '- MySQL itemId/db_itemId values not represented in CSV: **' . count($mysqlUnrepresented) . '**';
+$md[] = '';
+$md[] = '## 4) model_id audit';
+$md[] = "- Total CSV rows: **{$totalCsvRows}**";
+$md[] = "- Nonblank model_id rows: **" . count($csvModelNonblank) . "**";
+$md[] = "- Blank model_id rows: **{$csvModelBlank}**";
+$md[] = "- Duplicate model_id values: **" . count($csvModelDupes) . "**";
+$md[] = '- Duplicate model_id list:';
+foreach ($csvModelDupes as $v => $c) {
+    $md[] = "  - `{$v}` × {$c}";
+}
+$md[] = '';
+$md[] = '## 5) Classification';
+$md[] = "- Existing rows confidently linked by db_itemId: **{$linkedByDb}**";
+$md[] = "- Likely new insert candidates (blank db_itemId + unique nonblank model_id): **{$insertCandidates}**";
+$md[] = "- Rows requiring manual mapping: **{$manualMapping}**";
+$md[] = '';
+$md[] = '## Appendix (samples)';
+$md[] = '- Sample CSV db_itemId not found in MySQL (first 20): `' . implode('`, `', array_slice($csvNotFound, 0, 20)) . '`';
+$md[] = '- Sample MySQL values not in CSV (first 20): `' . implode('`, `', array_slice($mysqlUnrepresented, 0, 20)) . '`';
+
+file_put_contents($outPath, implode("\n", $md) . "\n");
+echo "Wrote {$outPath}\n";


### PR DESCRIPTION
### Motivation
- Provide a read-only readiness audit comparing the Excel-derived CSV source to the live MySQL `item` table so teams can plan imports/migrations without modifying DB state. 
- Verify `db_itemId` linkages and `model_id` fingerprints for duplicate detection, confident linking, and insert-candidate identification prior to any write actions. 

### Description
- Add a new PHP audit generator at `tools/reports/generate_db_itemid_modelid_readiness_audit.php` that reads `docs/data/SportWarehouse_ProductDB.csv` and computes requested `db_itemId` and `model_id` metrics. 
- The script performs only read operations against MySQL (SELECTs and `SHOW COLUMNS`) and gracefully records DB connection status without performing any writes, migrations, or repairs. 
- The generator emits a markdown report to `docs/operations/generated/2026-05-18-db_itemid-model_id-readiness-audit.md` containing CSV audit, live MySQL audit, cross-checks, `model_id` duplicates (including `nike_female_leggings` if present), and classification tallies. 

### Testing
- Ran `php -l tools/reports/generate_db_itemid_modelid_readiness_audit.php` and it reported no syntax errors. 
- Executed the script which produced the markdown report at `docs/operations/generated/2026-05-18-db_itemid-model_id-readiness-audit.md` and recorded the environment DB connection failure (`SQLSTATE[HY000] [2002] Connection refused`) while still outputting CSV-backed metrics. 
- Ran `git diff --check` to validate whitespace/patch hygiene and observed no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b1acf314c832491ef43a668e806a0)