### PR TITLE
Use ASCII duplicate marker in db_itemId/model_id readiness audit output

### DIFF
--- a/tools/reports/generate_db_itemid_modelid_readiness_audit.php
+++ b/tools/reports/generate_db_itemid_modelid_readiness_audit.php
@@ -206,7 +206,7 @@ $md[] = "- Blank model_id rows: **{$csvModelBlank}**";
 $md[] = "- Duplicate model_id values: **" . count($csvModelDupes) . "**";
 $md[] = '- Duplicate model_id list:';
 foreach ($csvModelDupes as $v => $c) {
-    $md[] = "  - `{$v}` × {$c}";
+    $md[] = "  - `{$v}` x {$c}";
 }
 $md[] = '';
 $md[] = '## 5) Classification';


### PR DESCRIPTION
### Motivation
- Replace the Unicode multiplication symbol with a plain ASCII `x` in the generated duplicate `model_id` list to avoid mojibake in Windows/PowerShell and keep generated markdown stable across environments.

### Description
- Updated `tools/reports/generate_db_itemid_modelid_readiness_audit.php` to emit `x` instead of `×` for duplicate `model_id` entries in the report.

### Testing
- Ran `php -l tools/reports/generate_db_itemid_modelid_readiness_audit.php` which reported no syntax errors. 
- Ran `git diff --check` which reported no trailing-whitespace or diff issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d0f1e7d2883248f45191e96aa842f)