### PR TITLE
Refine live schema verification for naming-governance duplicate pairs

### DIFF
--- a/docs/operations/generated/2026-05-20-live-schema-verification-report.md
+++ b/docs/operations/generated/2026-05-20-live-schema-verification-report.md
@@ -1,6 +1,6 @@
 # Live Schema Verification Report (Read-Only)
 
-- Generated: 2026-05-20 05:45:00 UTC
+- Generated: 2026-05-20 06:06:25 UTC
 - Source CSV: `docs/data/SportWarehouse_ProductDB.csv`
 - Migration design reference: `README/V-AUDIT/POST-AUDIT/2026-05-20-MySQL-Schema-Migration-Design-No-Execution.md`
 - DB status: connection failed (`SQLSTATE[HY000] [2002] Connection refused`)
@@ -49,6 +49,16 @@
 | `fitStyle` / `fit_style` | alias/mapping required | Neither form exists; importer mapping needed if required by CSV. |
 | `activityTags` / `activity_tags` | alias/mapping required | Neither form exists; importer mapping needed if required by CSV. |
 
+## 5A) Naming convention / duplicate-column governance
+- This section treats camelCase/snake_case duplicates as a **naming-governance architecture decision**, not simple schema drift.
+| Pair | camelCase in live `item` | snake_case in live `item` | CSV header form | Data occupancy/read-only comparison | Recommendation |
+|---|---|---|---|---|---|
+| `ageGroup` / `age_group` | no | no | camelCase (`ageGroup`) | DB unavailable or both columns not present for live read-only comparison. | manual decision required |
+| `sizeType` / `size_type` | no | no | camelCase (`sizeType`) | DB unavailable or both columns not present for live read-only comparison. | manual decision required |
+| `fitStyle` / `fit_style` | no | no | camelCase (`fitStyle`) | DB unavailable or both columns not present for live read-only comparison. | manual decision required |
+| `activityTags` / `activity_tags` | no | no | camelCase (`activityTags`) | DB unavailable or both columns not present for live read-only comparison. | manual decision required |
+| `CropAllowed` / `crop_allowed` | no | no | camelCase (`CropAllowed`) | DB unavailable or both columns not present for live read-only comparison. | manual decision required |
+
 ## 6) CSV-to-live schema comparison
 | CSV column | Expected runtime decision | Exact live item column exists | Alias/mapped live item column exists | Recommended planning status |
 |---|---|---|---|---|
@@ -95,7 +105,7 @@
 | `images2` | staging/import only | no | no | staging/import only |
 | `CropAllowed` | verify-first naming decision | no | no | verify-first compatibility decision |
 | `db_itemId` | verify live schema first; keep existing | no | no | verify-first compatibility decision |
-| `assignment_source` | staging/import only | no | no | staging/import only |
+| `assignment_source` | existing live column, but design classifies as staging/import-only; manual decision required before import allowlist | no | no | staging/import only |
 | `_images_helper_normalize` | staging/import only | no | no | staging/import only |
 
 ## 7) Protected-field verification
@@ -112,5 +122,9 @@
 - CSV columns supported via alias: **0**
 - CSV columns missing from live item and candidate runtime additions: **40**
 - CSV columns classified as staging/import only: **3**
+- Duplicate naming pairs detected: **5**
+- Duplicate naming pairs with both columns present: **0**
+- Duplicate naming pairs with value differences: **0**
 - Verify-first compatibility decisions: **2**
+- Manual naming-governance decisions required: **0**
 - Recommendation: DB was unreachable, so manual live schema review is still required before drafting illustrative migration SQL.

--- a/tools/reports/generate_live_schema_verification_report.php
+++ b/tools/reports/generate_live_schema_verification_report.php
@@ -63,6 +63,14 @@ $aliasPairs = [
 $stagingOnly = ['images2', 'assignment_source', '_images_helper_normalize'];
 $verifyFirst = ['CropAllowed', 'db_itemId'];
 
+$duplicateGovernancePairs = [
+    ['camel' => 'ageGroup', 'snake' => 'age_group'],
+    ['camel' => 'sizeType', 'snake' => 'size_type'],
+    ['camel' => 'fitStyle', 'snake' => 'fit_style'],
+    ['camel' => 'activityTags', 'snake' => 'activity_tags'],
+    ['camel' => 'CropAllowed', 'snake' => 'crop_allowed'],
+];
+
 $dbHost = sw_env('DB_HOST', '127.0.0.1');
 $dbName = sw_env('DB_NAME', 'sportswh');
 $dbUser = sw_env('DB_USER', 'root');
@@ -72,6 +80,7 @@ $dbError = null;
 $tableExists = ['item' => false, 'hero_override' => false];
 $itemColumns = [];
 $heroOverrideColumns = [];
+$duplicatePairStats = [];
 
 try {
     $pdo = new PDO(
@@ -96,6 +105,43 @@ try {
         );
         $stmt->execute(['schema' => $dbName, 'table_name' => 'item']);
         $itemColumns = $stmt->fetchAll(PDO::FETCH_ASSOC) ?: [];
+
+        foreach ($duplicateGovernancePairs as $pair) {
+            $camel = $pair['camel'];
+            $snake = $pair['snake'];
+            $quotedCamel = '`' . str_replace('`', '``', $camel) . '`';
+            $quotedSnake = '`' . str_replace('`', '``', $snake) . '`';
+            $sql = "SELECT
+                    COUNT(*) AS total_rows,
+                    SUM(CASE WHEN (NULLIF(TRIM(COALESCE({$quotedCamel}, '')), '') IS NULL) AND (NULLIF(TRIM(COALESCE({$quotedSnake}, '')), '') IS NULL) THEN 1 ELSE 0 END) AS both_blank,
+                    SUM(CASE WHEN (NULLIF(TRIM(COALESCE({$quotedCamel}, '')), '') IS NOT NULL) AND (NULLIF(TRIM(COALESCE({$quotedSnake}, '')), '') IS NULL) THEN 1 ELSE 0 END) AS only_camel,
+                    SUM(CASE WHEN (NULLIF(TRIM(COALESCE({$quotedCamel}, '')), '') IS NULL) AND (NULLIF(TRIM(COALESCE({$quotedSnake}, '')), '') IS NOT NULL) THEN 1 ELSE 0 END) AS only_snake,
+                    SUM(CASE WHEN (NULLIF(TRIM(COALESCE({$quotedCamel}, '')), '') IS NOT NULL) AND (NULLIF(TRIM(COALESCE({$quotedSnake}, '')), '') IS NOT NULL) AND (TRIM(CAST({$quotedCamel} AS CHAR)) = TRIM(CAST({$quotedSnake} AS CHAR))) THEN 1 ELSE 0 END) AS both_same,
+                    SUM(CASE WHEN (NULLIF(TRIM(COALESCE({$quotedCamel}, '')), '') IS NOT NULL) AND (NULLIF(TRIM(COALESCE({$quotedSnake}, '')), '') IS NOT NULL) AND (TRIM(CAST({$quotedCamel} AS CHAR)) <> TRIM(CAST({$quotedSnake} AS CHAR))) THEN 1 ELSE 0 END) AS both_diff
+                FROM item";
+            $pairStmt = $pdo->query($sql);
+            $stats = $pairStmt ? ($pairStmt->fetch(PDO::FETCH_ASSOC) ?: []) : [];
+
+            $diffSql = "SELECT itemId, itemName, CAST({$quotedCamel} AS CHAR) AS camel_value, CAST({$quotedSnake} AS CHAR) AS snake_value
+                        FROM item
+                        WHERE NULLIF(TRIM(COALESCE({$quotedCamel}, '')), '') IS NOT NULL
+                          AND NULLIF(TRIM(COALESCE({$quotedSnake}, '')), '') IS NOT NULL
+                          AND TRIM(CAST({$quotedCamel} AS CHAR)) <> TRIM(CAST({$quotedSnake} AS CHAR))
+                        ORDER BY itemId ASC
+                        LIMIT 10";
+            $diffStmt = $pdo->query($diffSql);
+            $diffExamples = $diffStmt ? ($diffStmt->fetchAll(PDO::FETCH_ASSOC) ?: []) : [];
+
+            $duplicatePairStats[$camel . '|' . $snake] = [
+                'total_rows' => (int)($stats['total_rows'] ?? 0),
+                'both_blank' => (int)($stats['both_blank'] ?? 0),
+                'only_camel' => (int)($stats['only_camel'] ?? 0),
+                'only_snake' => (int)($stats['only_snake'] ?? 0),
+                'both_same' => (int)($stats['both_same'] ?? 0),
+                'both_diff' => (int)($stats['both_diff'] ?? 0),
+                'diff_examples' => $diffExamples,
+            ];
+        }
     }
 
     if ($tableExists['hero_override']) {
@@ -133,6 +179,7 @@ $driftPairs = [
 
 $csvExact = 0;
 $csvAlias = 0;
+$csvDuplicateRisk = 0;
 $csvMissingRuntime = 0;
 $csvStaging = 0;
 $csvVerifyFirst = 0;
@@ -151,8 +198,13 @@ foreach ($headers as $csvCol) {
         $status = 'verify-first compatibility decision';
         $csvVerifyFirst++;
     } elseif ($exact) {
-        $status = 'already supported';
-        $csvExact++;
+        if ($aliasFound && in_array($csvCol, array_column($duplicateGovernancePairs, 'camel'), true)) {
+            $status = 'supported, but duplicate naming decision required';
+            $csvDuplicateRisk++;
+        } else {
+            $status = 'already supported';
+            $csvExact++;
+        }
     } elseif ($aliasFound) {
         $status = 'supported via alias';
         $csvAlias++;
@@ -162,7 +214,9 @@ foreach ($headers as $csvCol) {
 
     $comparisonRows[] = [
         'csv' => $csvCol,
-        'decision' => $runtimeDecisions[$csvCol] ?? 'not explicitly specified in migration design',
+        'decision' => $csvCol === 'assignment_source'
+            ? 'existing live column, but design classifies as staging/import-only; manual decision required before import allowlist'
+            : ($runtimeDecisions[$csvCol] ?? 'not explicitly specified in migration design'),
         'exact' => $exact ? 'yes' : 'no',
         'alias' => $aliasFound ? ('yes (`' . $aliasTarget . '`)') : 'no',
         'status' => $status,
@@ -252,6 +306,69 @@ foreach ($driftPairs as [$a, $b]) {
     $md[] = '| `' . $a . '` / `' . $b . '` | ' . $class . ' | ' . $notes . ' |';
 }
 $md[] = '';
+$md[] = '## 5A) Naming convention / duplicate-column governance';
+$md[] = '- This section treats camelCase/snake_case duplicates as a **naming-governance architecture decision**, not simple schema drift.';
+$md[] = '| Pair | camelCase in live `item` | snake_case in live `item` | CSV header form | Data occupancy/read-only comparison | Recommendation |';
+$md[] = '|---|---|---|---|---|---|';
+foreach ($duplicateGovernancePairs as $pair) {
+    $camel = $pair['camel'];
+    $snake = $pair['snake'];
+    $hasCamel = isset($itemColumnSet[$camel]);
+    $hasSnake = isset($itemColumnSet[$snake]);
+    $csvForm = in_array($camel, $headers, true) ? ('camelCase (`' . $camel . '`)') : (in_array($snake, $headers, true) ? ('snake_case (`' . $snake . '`)') : 'not present in CSV headers');
+
+    $comparison = 'DB unavailable or both columns not present for live read-only comparison.';
+    $recommendation = 'manual decision required';
+
+    if ($dbError === null && $tableExists['item'] && $hasCamel && $hasSnake) {
+        $key = $camel . '|' . $snake;
+        $stats = $duplicatePairStats[$key] ?? null;
+        if ($stats !== null) {
+            if ($stats['both_diff'] > 0) {
+                $relationship = 'both columns contain differing values';
+                $recommendation = 'manual decision required';
+            } elseif ($stats['only_snake'] > 0 && $stats['only_camel'] === 0) {
+                $relationship = 'snake_case mostly populated, camelCase mostly blank';
+                $recommendation = 'prefer runtime snake_case';
+            } elseif ($stats['only_camel'] > 0 && $stats['only_snake'] === 0) {
+                $relationship = 'camelCase mostly populated, snake_case mostly blank';
+                $recommendation = 'prefer CSV camelCase';
+            } elseif ($stats['both_same'] > 0 && $stats['only_camel'] === 0 && $stats['only_snake'] === 0) {
+                $relationship = 'values identical where populated';
+                $recommendation = 'keep existing temporarily with alias mapping';
+            } else {
+                $relationship = 'mixed occupancy across both naming forms';
+                $recommendation = 'manual decision required';
+            }
+            $comparison = sprintf(
+                'rows=%d; both blank=%d; only camel=%d; only snake=%d; both same=%d; both different=%d; %s',
+                $stats['total_rows'],
+                $stats['both_blank'],
+                $stats['only_camel'],
+                $stats['only_snake'],
+                $stats['both_same'],
+                $stats['both_diff'],
+                $relationship
+            );
+        }
+    }
+
+    $md[] = '| `' . $camel . '` / `' . $snake . '` | ' . ($hasCamel ? 'yes' : 'no') . ' | ' . ($hasSnake ? 'yes' : 'no') . ' | ' . $csvForm . ' | ' . $comparison . ' | ' . $recommendation . ' |';
+
+    if ($dbError === null && $tableExists['item'] && $hasCamel && $hasSnake) {
+        $key = $camel . '|' . $snake;
+        $stats = $duplicatePairStats[$key] ?? null;
+        if ($stats !== null && $stats['both_diff'] > 0) {
+            $md[] = '';
+            $md[] = '- First 10 differing examples for `' . $camel . '` vs `' . $snake . '`: ';
+            $md[] = '  - Columns: `itemId`, `itemName`, camelCase value, snake_case value';
+            foreach ($stats['diff_examples'] as $ex) {
+                $md[] = '  - `itemId=' . (string)$ex['itemId'] . '`, `itemName=' . str_replace('`', '\`', (string)$ex['itemName']) . '`, camel=`' . str_replace('`', '\`', (string)$ex['camel_value']) . '`, snake=`' . str_replace('`', '\`', (string)$ex['snake_value']) . '`';
+            }
+        }
+    }
+}
+$md[] = '';
 $md[] = '## 6) CSV-to-live schema comparison';
 $md[] = '| CSV column | Expected runtime decision | Exact live item column exists | Alias/mapped live item column exists | Recommended planning status |';
 $md[] = '|---|---|---|---|---|';
@@ -273,7 +390,26 @@ $md[] = '- CSV columns already supported exactly: **' . $csvExact . '**';
 $md[] = '- CSV columns supported via alias: **' . $csvAlias . '**';
 $md[] = '- CSV columns missing from live item and candidate runtime additions: **' . $csvMissingRuntime . '**';
 $md[] = '- CSV columns classified as staging/import only: **' . $csvStaging . '**';
+$duplicateDetected = count($duplicateGovernancePairs);
+$duplicateBothPresent = 0;
+$duplicateWithDiffs = 0;
+foreach ($duplicateGovernancePairs as $pair) {
+    $camel = $pair['camel'];
+    $snake = $pair['snake'];
+    if (isset($itemColumnSet[$camel]) && isset($itemColumnSet[$snake])) {
+        $duplicateBothPresent++;
+        $stats = $duplicatePairStats[$camel . '|' . $snake] ?? null;
+        if ($stats !== null && $stats['both_diff'] > 0) {
+            $duplicateWithDiffs++;
+        }
+    }
+}
+$manualNamingGovernance = $duplicateBothPresent;
+$md[] = '- Duplicate naming pairs detected: **' . $duplicateDetected . '**';
+$md[] = '- Duplicate naming pairs with both columns present: **' . $duplicateBothPresent . '**';
+$md[] = '- Duplicate naming pairs with value differences: **' . $duplicateWithDiffs . '**';
 $md[] = '- Verify-first compatibility decisions: **' . $csvVerifyFirst . '**';
+$md[] = '- Manual naming-governance decisions required: **' . $manualNamingGovernance . '**';
 if ($dbError !== null) {
     $md[] = '- Recommendation: DB was unreachable, so manual live schema review is still required before drafting illustrative migration SQL.';
 } elseif (!$tableExists['item']) {


### PR DESCRIPTION
### Motivation
- Naming-convention drift between CSV headers and the live `item` table has produced camelCase/snake_case duplicates that require an explicit architecture/governance decision rather than being counted as simple schema drift. 
- The report should surface read-only occupancy and value-difference metrics to inform a manual decision before any migration or import is executed. 
- `assignment_source`, `db_itemId`, and `model_id` semantics need explicit handling in the verification output per the migration design constraints.

### Description
- Added a dedicated list of duplicate-governance pairs (`$duplicateGovernancePairs`) for the five targeted camelCase/snake_case pairs and a `$duplicatePairStats` collection to hold read-only statistics. 
- Run read-only value-aggregation queries (counts: `total_rows`, `both_blank`, `only_camel`, `only_snake`, `both_same`, `both_diff`) and captured up to 10 differing examples per pair; all queries use `SELECT` reads only and do not write or alter schema. 
- Introduced a new report section “## 5A) Naming convention / duplicate-column governance” that reports live presence, CSV header form, occupancy/value comparison, and a recommendation label per pair. 
- Updated CSV-to-live classification so CSV fields with exact live columns that also have alias forms receive `supported, but duplicate naming decision required` rather than `already supported`, and added a special decision text for `assignment_source`. 
- Added summary counters for duplicate naming pairs detected, both-present pairs, pairs with value differences, and manual naming-governance decisions required. 
- Regenerated `docs/operations/generated/2026-05-20-live-schema-verification-report.md` to reflect the new output while preserving the read-only, no-migration constraints and leaving `db_itemId`/`model_id` handling intent unchanged.

### Testing
- Syntax check succeeded with `php -l tools/reports/generate_live_schema_verification_report.php`. 
- Script executed in CI environment with `php tools/reports/generate_live_schema_verification_report.php` and produced the report file; the run detected a DB connection failure and therefore marked value-comparison content as unavailable rather than faking data. 
- `git diff --check` returned clean results for the modified files. 
- Note: meaningful read-only value comparisons require the script to run against a reachable MySQL instance locally, so run `php tools/reports/generate_live_schema_verification_report.php` with local DB access to populate the occupancy and differing-example sections.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d4f06d79c8324baa22bedfa08d1fb)