### PR TITLE
docs: widen itemName_fully_derived draft SQL type

### DIFF
--- a/README/V-AUDIT/POST-AUDIT/2026-05-21-Illustrative-MySQL-Migration-SQL-Plan-Not-Executable.md
+++ b/README/V-AUDIT/POST-AUDIT/2026-05-21-Illustrative-MySQL-Migration-SQL-Plan-Not-Executable.md
@@ -52,7 +52,7 @@ CREATE TABLE item_staging (
   brand VARCHAR(100) NULL,
   gender VARCHAR(50) NULL,
   itemName TEXT NULL,
-  itemName_fully_derived VARCHAR(10) NULL,
+  itemName_fully_derived VARCHAR(255) NULL,
   model_id VARCHAR(255) NULL,
   product_domain VARCHAR(100) NULL,
   collection VARCHAR(255) NULL,
@@ -109,7 +109,7 @@ Only runtime candidate catalogue fields are shown below.
 -- DRAFT / ILLUSTRATIVE ONLY / NOT FOR EXECUTION
 ALTER TABLE item
   ADD COLUMN model_id VARCHAR(255) NULL,
-  ADD COLUMN itemName_fully_derived VARCHAR(10) NULL,
+  ADD COLUMN itemName_fully_derived VARCHAR(255) NULL,
   ADD COLUMN product_domain VARCHAR(100) NULL,
   ADD COLUMN collection VARCHAR(255) NULL,
   ADD COLUMN model_family VARCHAR(255) NULL,


### PR DESCRIPTION
### Motivation
- The illustrative migration SQL used `itemName_fully_derived VARCHAR(10)` which is too short for a derived product-name/source-text field. 
- The planning document should treat this as derived-system source text and therefore use a safer draft column type to avoid misleading readers of the non-executable plan.

### Description
- Replaced `itemName_fully_derived VARCHAR(10) NULL` with `itemName_fully_derived VARCHAR(255) NULL` in the staging `CREATE TABLE` snippet. 
- Applied the same replacement in the illustrative `ALTER TABLE item` snippet where the draft column type appeared. 
- Kept all SQL-shaped snippets explicitly marked `DRAFT / ILLUSTRATIVE ONLY / NOT FOR EXECUTION` and limited the change to documentation-only without creating executable SQL files.

### Testing
- Ran `git diff --check` which reported no issues. 
- Reviewed the diff for the target file with `git diff -- README/V-AUDIT/POST-AUDIT/2026-05-21-Illustrative-MySQL-Migration-SQL-Plan-Not-Executable.md | sed -n '1,200p'` to confirm only the intended lines changed. 
- Previewed the updated markdown snippets with `sed -n '40,130p'` and `nl -ba ... | sed -n '48,120p'` to verify the `VARCHAR(255) NULL` occurrences and the preserved DRAFT markings.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e43edd7788324b75fc3e0d09c8634)