### PR TITLE
Add skeleton-only CSV-to-MySQL dry-run importer placeholder

### DIFF
--- a/tools/migration/csv_mysql_dry_run_importer.php
+++ b/tools/migration/csv_mysql_dry_run_importer.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * CSV-to-MySQL dry-run importer placeholder (non-executing skeleton only).
+ *
+ * This file is intentionally a non-executing placeholder.
+ * Future dry-run importer scope is defined by planning/governance documents in:
+ * README/V-AUDIT/POST-AUDIT/
+ *
+ * No importer implementation is approved yet.
+ * No database writes are approved.
+ * No CSV reads are performed by this skeleton.
+ * No report generation is performed by this skeleton.
+ * Protected fields must never be written.
+ * Deferred governance fields remain excluded.
+ * Public/admin invocation is not supported.
+ */
+
+if (PHP_SAPI !== 'cli') {
+    fwrite(STDERR, "This placeholder supports CLI invocation only.\n");
+    exit(2);
+}
+
+$args = $argv;
+array_shift($args);
+
+$writeLikeFlags = [
+    '--execute',
+    '--apply',
+    '--write-db',
+    '--update',
+    '--insert',
+    '--alter',
+    '--repair',
+    '--backfill-db-item-id',
+    '--enforce-model-id-unique',
+    '--write-reports',
+];
+
+$detectedWriteLikeFlags = array_values(array_intersect($args, $writeLikeFlags));
+
+if ($detectedWriteLikeFlags !== []) {
+    fwrite(STDERR, "Write/execution flags are not supported by this skeleton: " . implode(', ', $detectedWriteLikeFlags) . "\n");
+}
+
+fwrite(STDOUT, "CSV-to-MySQL dry-run importer skeleton exists, but implementation is not yet approved.\n");
+fwrite(STDOUT, "No CSV was read.\n");
+fwrite(STDOUT, "No database connection was opened.\n");
+fwrite(STDOUT, "No SQL was executed.\n");
+fwrite(STDOUT, "No reports were generated.\n");
+
+exit(1);


### PR DESCRIPTION
### Motivation
- Provide a safe, non-executing CLI placeholder for a future CSV-to-MySQL dry-run importer so the project can progress through the approved skeleton workflow. 
- Capture governance constraints in-code to make clear no import implementation, DB writes, CSV reads, or report generation are approved. 
- Prevent accidental use by ensuring the tool explicitly rejects write-style flags and exits non-zero.

### Description
- Add `tools/migration/csv_mysql_dry_run_importer.php` as a CLI-only, valid PHP skeleton with a top-level docblock documenting that this is a non-executing placeholder and listing governance constraints. 
- Implement CLI gating via `PHP_SAPI` and safe argument handling that detects and reports write/execution-style flags (for example `--execute`, `--apply`, `--write-db`, etc.) while performing no side effects. 
- Emit clear runtime messages stating that no CSV was read, no DB connection was opened, no SQL executed, and no reports were generated, and exit with a non-zero status to indicate non-implementation. 
- Create the `tools/migration` directory only if needed and add the single new file without adding any implementation logic, file writes, DB connections, CSV parsing, report generation, admin UI, or public routes.

### Testing
- Ran `php -l tools/migration/csv_mysql_dry_run_importer.php` and it reported "No syntax errors detected". 
- Executed `php tools/migration/csv_mysql_dry_run_importer.php --dry-run` and it printed the safe not-implemented messages and exited with code `1`. 
- Executed `php tools/migration/csv_mysql_dry_run_importer.php --execute` and it printed the safe not-implemented messages, reported the unsupported write flag, and exited with code `1`. 
- Ran `git diff --check` and `git status --short` as repo validations and observed no lint or diff errors related to the new skeleton file.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e9aca010483248e1ab2c04085deb9)