### PR TITLE
Refine dry-run importer rejection safety messaging

### DIFF
--- a/tools/migration/csv_mysql_dry_run_importer.php
+++ b/tools/migration/csv_mysql_dry_run_importer.php
@@ -87,8 +87,17 @@ $printStatus = static function (): void {
     fwrite(STDOUT, "- write/execution flags remain unsupported\n");
 };
 
+$printNoSideEffectSafety = static function (): void {
+    fwrite(STDOUT, "No CSV was read.\n");
+    fwrite(STDOUT, "No database connection was opened.\n");
+    fwrite(STDOUT, "No SQL was executed.\n");
+    fwrite(STDOUT, "No reports were generated.\n");
+    fwrite(STDOUT, "No files were written.\n");
+};
+
 if ($detectedWriteLikeFlags !== []) {
     fwrite(STDERR, "Write/execution flags are not supported by this skeleton: " . implode(', ', $detectedWriteLikeFlags) . "\n");
+    $printNoSideEffectSafety();
     exit(1);
 }
 
@@ -102,6 +111,7 @@ $unknownArgs = array_values(array_diff($args, $recognizedArgs));
 
 if ($unknownArgs !== []) {
     fwrite(STDERR, "Unsupported option(s): " . implode(', ', $unknownArgs) . ". Use --help.\n");
+    $printNoSideEffectSafety();
     exit(1);
 }
 
@@ -117,11 +127,7 @@ if (in_array('--status', $args, true)) {
 
 if (in_array('--dry-run', $args, true)) {
     fwrite(STDERR, "--dry-run is planned but not implemented in this approved skeleton stage.\n");
-    fwrite(STDOUT, "No CSV was read.\n");
-    fwrite(STDOUT, "No database connection was opened.\n");
-    fwrite(STDOUT, "No SQL was executed.\n");
-    fwrite(STDOUT, "No reports were generated.\n");
-    fwrite(STDOUT, "No files were written.\n");
+    $printNoSideEffectSafety();
     exit(1);
 }
 


### PR DESCRIPTION
### Motivation
- Ensure that rejected write/execution flags and unknown CLI options print explicit, consistent no-side-effect safety guarantees before exiting non-zero.
- Avoid duplicated safety-line code by centralizing the explicit guarantees in a small shared helper.

### Description
- Added a shared helper `$printNoSideEffectSafety` to `tools/migration/csv_mysql_dry_run_importer.php` that prints the explicit no-side-effect guarantees (`No CSV was read.`, `No database connection was opened.`, `No SQL was executed.`, `No reports were generated.`, `No files were written.`).
- Invoke the helper when rejecting write/execution flags, when rejecting unknown options, and when handling the planned-but-not-implemented `--dry-run` path, while preserving the existing error messages and non-zero exit codes.
- Retained CLI-only enforcement and the existing `--help` and `--status` behaviors and exit codes, and did not add any importer implementation or side-effecting logic.

### Testing
- Ran `php -l tools/migration/csv_mysql_dry_run_importer.php` and it reported no syntax errors.
- Ran `php tools/migration/csv_mysql_dry_run_importer.php --help` and `--status` and both exited successfully and printed expected output.
- Ran `php tools/migration/csv_mysql_dry_run_importer.php --dry-run`, `--execute`, and `--unknown-option` and each exited non-zero while printing the rejection/unsupported message plus the shared no-side-effect safety guarantees.
- Ran `git diff --check` and `git status --short` as part of validation and observed only the intended modified skeleton file in the working tree changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ea6d3b68c8324be5100d3b648e491)