### PR TITLE
Fix UTF-8 BOM handling in --check-csv-header

### DIFF
--- a/tools/migration/csv_mysql_dry_run_importer.php
+++ b/tools/migration/csv_mysql_dry_run_importer.php
@@ -143,6 +143,16 @@ $checkCsvHeader = static function () use ($printNoSideEffectSafetyHeaderCheck): 
     }
 
     $header = array_values(array_map(static fn (string $value): string => trim($value), $header));
+
+    $bomDetectedInFirstHeaderField = false;
+    if ($header !== []) {
+        $utf8Bom = "\xEF\xBB\xBF";
+        if (strncmp($header[0], $utf8Bom, strlen($utf8Bom)) === 0) {
+            $bomDetectedInFirstHeaderField = true;
+            $header[0] = substr($header[0], strlen($utf8Bom));
+        }
+    }
+
     $headerSet = array_fill_keys($header, true);
 
     $missingRequired = array_values(array_filter(
@@ -174,6 +184,7 @@ $checkCsvHeader = static function () use ($printNoSideEffectSafetyHeaderCheck): 
     ));
 
     fwrite(STDOUT, "Detected header count: " . count($header) . "\n");
+    fwrite(STDOUT, "UTF-8 BOM detected in first header field: " . ($bomDetectedInFirstHeaderField ? 'yes' : 'no') . "\n");
     fwrite(STDOUT, "Required header fields present: " . ($missingRequired === [] ? 'yes' : 'no') . "\n");
     fwrite(STDOUT, "Missing required header fields: " . ($missingRequired === [] ? '(none)' : implode(', ', $missingRequired)) . "\n");
     fwrite(STDOUT, "Deferred governance fields found: " . ($foundDeferred === [] ? '(none)' : implode(', ', $foundDeferred)) . "\n");


### PR DESCRIPTION
### Motivation
- The CSV header in `docs/data/SportWarehouse_ProductDB.csv` can include a UTF-8 BOM on the first field which caused `brand` to be misclassified as missing and unknown. 
- The goal is to normalize a UTF-8 BOM from the first header field while preserving the strict header-only, no-side-effect behavior of `--check-csv-header`.

### Description
- Added byte-prefix detection and removal for a UTF-8 BOM on the first header field using `"\xEF\xBB\xBF"` with `strncmp` and `substr` in `tools/migration/csv_mysql_dry_run_importer.php` before classification. 
- Introduced a `UTF-8 BOM detected in first header field: yes|no` console line so BOM normalization status is explicit. 
- Preserved existing behavior: only the header row is read, no DB connections/SQL/reports/files are created, and exit codes/unsafe flags remain unchanged.

### Testing
- Ran `php -l tools/migration/csv_mysql_dry_run_importer.php` and it reported no syntax errors (success). 
- Ran `php tools/migration/csv_mysql_dry_run_importer.php --check-csv-header` and it printed BOM detection (`yes` for the provided CSV), showed `brand` present, did not list a BOM-prefixed `brand` as unknown, and exited `0` (success). 
- Verified help/status/dry-run/execute/unknown-option paths with `--help`, `--status`, `--dry-run`, `--execute`, and an unsupported option respectively, and observed expected exit codes and unchanged safety messages (`--dry-run` and execution flags exit non-zero as before). 
- Ran `git diff --check` and `git status --short` to validate repository state and that only the intended file was modified (success).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ef00c943083248d2debebcccd6109)