### PR TITLE
Clean duplicate database-connection wording in importer --status output

### DIFF
--- a/tools/migration/csv_mysql_dry_run_importer.php
+++ b/tools/migration/csv_mysql_dry_run_importer.php
@@ -78,13 +78,12 @@ $printHelp = static function (): void {
 $printStatus = static function (): void {
     fwrite(STDOUT, "Skeleton status:\n");
     fwrite(STDOUT, "- skeleton exists\n");
-    fwrite(STDOUT, "- implementation not approved\n");
+    fwrite(STDOUT, "- Importer implementation approved: no\n");
     fwrite(STDOUT, "- CSV header check implemented: yes\n");
     fwrite(STDOUT, "- Full CSV row reading implemented: no\n");
     fwrite(STDOUT, "- Database connection implemented: no\n");
+    fwrite(STDOUT, "- SQL execution implemented: no\n");
     fwrite(STDOUT, "- Report generation implemented: no\n");
-    fwrite(STDOUT, "- database connection not implemented\n");
-    fwrite(STDOUT, "- SQL execution not implemented\n");
     fwrite(STDOUT, "- protected fields remain excluded by governance\n");
     fwrite(STDOUT, "- deferred governance fields remain excluded\n");
     fwrite(STDOUT, "- write/execution flags remain unsupported\n");


### PR DESCRIPTION
### Motivation
- Remove a duplicated database-connection line in the `--status` output of `tools/migration/csv_mysql_dry_run_importer.php` so the CLI status is clearer while preserving the skeleton's safety-first behavior.

### Description
- Adjusted the `--status` output in `tools/migration/csv_mysql_dry_run_importer.php` to remove the redundant "database connection not implemented" line and normalize the implementation-state wording (added `Importer implementation approved: no` and `SQL execution implemented: no`) with no changes to importer logic or side-effect behavior.

### Testing
- Verified with `php -l tools/migration/csv_mysql_dry_run_importer.php`, `php tools/migration/csv_mysql_dry_run_importer.php --status`, `--help`, `--check-csv-header`, `--dry-run` (expected non-zero), `--execute` (expected non-zero), `--unknown-option` (expected non-zero), and ran `git diff --check` and `git status --short`, and all checks behaved as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ef721d7188324aee44222c1796d68)