### PR TITLE
Fix BOM handling in --show-frontend-readiness-summary header checks

### DIFF
--- a/tools/migration/csv_mysql_dry_run_importer.php
+++ b/tools/migration/csv_mysql_dry_run_importer.php
@@ -952,6 +952,13 @@ $showFrontendReadinessSummary = static function () use ($printNoSideEffectSafety
         return 1;
     }
     $header = array_values(array_map(static fn (string $value): string => trim($value), $header));
+    if ($header !== []) {
+        $utf8Bom = "\xEF\xBB\xBF";
+        if (strncmp($header[0], $utf8Bom, strlen($utf8Bom)) === 0) {
+            $header[0] = substr($header[0], strlen($utf8Bom));
+        }
+    }
+
     $dbItemIdColumnIndex = array_search('db_itemId', $header, true);
     if ($dbItemIdColumnIndex === false) {
         fclose($handle);


### PR DESCRIPTION
### Motivation
- `--show-frontend-readiness-summary` was flagging required diagnostic columns (e.g., `brand`) as missing when the first CSV header field contained a UTF-8 BOM, because BOM normalization was not applied before policy column checks.
- Other safe CSV modes already normalize the BOM on the first header field, so this change brings the frontend summary mode into alignment to avoid false-positive missing-column errors.

### Description
- Added UTF-8 BOM normalization on the first header field immediately after trimming the header in the `--show-frontend-readiness-summary` path of `tools/migration/csv_mysql_dry_run_importer.php` so BOM-prefixed `brand` is recognized.
- Reused the same BOM-detection/substr pattern already used by other CSV-check modes to keep behavior consistent and minimal.
- Preserved existing CLI-only, CSV-only, console-only, no-DB/no-SQL/no-write safety guarantees and retained fatal behavior for genuinely missing structural columns.
- Only modified `tools/migration/csv_mysql_dry_run_importer.php` and did not change CSV data, database behavior, report generation, or importer logic.

### Testing
- Ran `php -l tools/migration/csv_mysql_dry_run_importer.php` and it returned no syntax errors.
- Ran `php tools/migration/csv_mysql_dry_run_importer.php --show-frontend-readiness-summary` and it produced the frontend summary successfully and exited `0` when no fatal structural mismatch existed.
- Ran `php tools/migration/csv_mysql_dry_run_importer.php --check-required-fields`, `--show-remediation-guidance`, `--check-csv-header`, and `--check-csv-baseline` and each returned expected successful output.
- Ran `php tools/migration/csv_mysql_dry_run_importer.php --help`, `--status`, `--dry-run` (expected non-zero), `--execute` (expected non-zero), and `--unknown-option` (expected non-zero) and observed expected exit behavior.
- Ran `git diff --check` and `git status --short` to validate repository state after the single-file change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1006b9d80c8324bf9b52086c06279b)