### PR TITLE
Add safe --show-excel-remediation-summary CLI mode

### DIFF
--- a/tools/migration/csv_mysql_dry_run_importer.php
+++ b/tools/migration/csv_mysql_dry_run_importer.php
@@ -60,6 +60,7 @@ $printHelp = static function (): void {
     fwrite(STDOUT, "  --check-required-fields  Check required CSV fields for blank values without importing.\n");
     fwrite(STDOUT, "  --show-remediation-guidance  Show CSV-only remediation guidance for readiness findings without writing files.\n");
     fwrite(STDOUT, "  --show-frontend-readiness-summary  Show CSV-only frontend readiness summary without writing files.\n");
+    fwrite(STDOUT, "  --show-excel-remediation-summary  Show CSV-only Excel/source remediation summary without writing files.\n");
     fwrite(STDOUT, "  --dry-run  Planned option; not implemented (exits non-zero).\n\n");
 
     fwrite(STDOUT, "Explicitly disallowed options (unsupported):\n");
@@ -98,6 +99,7 @@ $printStatus = static function (): void {
     fwrite(STDOUT, "- CSV required-field completeness check implemented: yes\n");
     fwrite(STDOUT, "- CSV remediation guidance implemented: yes\n");
     fwrite(STDOUT, "- CSV frontend readiness summary implemented: yes\n");
+    fwrite(STDOUT, "- CSV Excel remediation summary implemented: yes\n");
     fwrite(STDOUT, "- CSV required-field completeness check scope: CSV-only required-field blank/present scanning (no database comparison, row matching, insert preview, importer classification, updates, inserts, backfill, report generation, or writes)\n");
     fwrite(STDOUT, "- Full importer row classification implemented: no\n");
     fwrite(STDOUT, "- Database connection implemented: no\n");
@@ -108,6 +110,7 @@ $printStatus = static function (): void {
     fwrite(STDOUT, "- write/execution flags remain unsupported\n");
     fwrite(STDOUT, "- Remediation guidance output mode: console-only (no report file generation, no CSV/database modifications)\n");
     fwrite(STDOUT, "- Frontend readiness summary mode: console-only (no report file generation, no CSV/database/frontend behavior modifications)\n");
+    fwrite(STDOUT, "- Excel remediation summary mode: console-only (no report file generation, no CSV/database modifications)\n");
     fwrite(STDOUT, "- File writes implemented: no\n");
 };
 
@@ -1068,6 +1071,60 @@ $showFrontendReadinessSummary = static function () use ($printNoSideEffectSafety
     return $structuralFailure ? 1 : 0;
 };
 
+
+$showExcelRemediationSummary = static function () use ($checkRequiredFields, $checkModelIdDuplicates): int {
+    $exitCode = $checkRequiredFields();
+    fwrite(STDOUT, "
+Excel/CSV remediation summary:
+");
+    fwrite(STDOUT, "- Source identity/linkage fixes
+");
+    fwrite(STDOUT, "  - field: external_item_id
+");
+    fwrite(STDOUT, "  - suggested Excel/CSV action: Fill or confirm external_item_id in the Excel/CSV source if source linkage is required for likely-new rows.
+");
+    fwrite(STDOUT, "- Likely-new insert readiness source fixes
+");
+    fwrite(STDOUT, "  - field: categoryName
+");
+    fwrite(STDOUT, "  - suggested Excel/CSV action: Fill categoryName in the Excel/CSV source for likely-new rows before insert/frontend readiness.
+");
+    fwrite(STDOUT, "  - field: price
+");
+    fwrite(STDOUT, "  - suggested Excel/CSV action: Fill price in the Excel/CSV source for likely-new rows before insert/frontend readiness.
+");
+    fwrite(STDOUT, "- Frontend-readiness source fixes
+");
+    fwrite(STDOUT, "  - field: images
+");
+    fwrite(STDOUT, "  - suggested Excel/CSV action: Add or map image/source asset values in the Excel/CSV source for likely-new rows before frontend readiness.
+");
+    fwrite(STDOUT, "- Accessibility/content source fixes
+");
+    fwrite(STDOUT, "  - field: altText / ariaText
+");
+    fwrite(STDOUT, "  - suggested Excel/CSV action: Improve accessibility text in the Excel/CSV source if these fields remain source-managed; otherwise flag as possible future admin remediation.
+");
+    fwrite(STDOUT, "  - field: description
+");
+    fwrite(STDOUT, "  - suggested Excel/CSV action: Fill or improve descriptions in Excel/CSV if descriptions are source-managed; otherwise flag as possible future admin remediation.
+");
+    fwrite(STDOUT, "- Governance/source-policy decisions
+");
+    fwrite(STDOUT, "  - field: parentCategory
+");
+    fwrite(STDOUT, "  - suggested Excel/CSV action: Do not force an Excel edit yet. Decide whether parentCategory is derivable, optional, future taxonomy, or should be remediated in Excel/CSV.
+");
+    fwrite(STDOUT, "
+Known model_id duplicate governance reminder:
+");
+    fwrite(STDOUT, "  - Resolve or explicitly govern the duplicate model_id group nike_female_leggings x 2 before model_id uniqueness enforcement.
+");
+    fwrite(STDOUT, "Console guidance only: no report file generated
+");
+    return $exitCode;
+};
+
 $showRemediationGuidance = static function () use ($checkRequiredFields): int {
     return $checkRequiredFields();
 };
@@ -1130,7 +1187,7 @@ if ($args === []) {
     exit(1);
 }
 
-$recognizedArgs = ['--help', '--status', '--check-csv-header', '--check-csv-row-count', '--check-model-id-duplicates', '--check-db-item-id-integrity', '--check-csv-baseline', '--check-required-fields', '--show-remediation-guidance', '--show-frontend-readiness-summary', '--dry-run'];
+$recognizedArgs = ['--help', '--status', '--check-csv-header', '--check-csv-row-count', '--check-model-id-duplicates', '--check-db-item-id-integrity', '--check-csv-baseline', '--check-required-fields', '--show-remediation-guidance', '--show-frontend-readiness-summary', '--show-excel-remediation-summary', '--dry-run'];
 $unknownArgs = array_values(array_diff($args, $recognizedArgs));
 
 if ($unknownArgs !== []) {
@@ -1185,6 +1242,10 @@ if (in_array('--show-remediation-guidance', $args, true)) {
 
 if (in_array('--show-frontend-readiness-summary', $args, true)) {
     exit($showFrontendReadinessSummary());
+}
+
+if (in_array('--show-excel-remediation-summary', $args, true)) {
+    exit($showExcelRemediationSummary());
 }
 
 fwrite(STDERR, "Unsupported invocation. Use --help.\n");


### PR DESCRIPTION
### Motivation
- Provide a safe, read-only console mode that summarizes Excel/CSV source remediation items so maintainers know what to fix in the source-of-truth before insert/frontend readiness or governance sign-off. 
- Keep all behavior strictly CSV-only and console-only while reusing existing CSV policy/readiness logic to avoid drift between similar diagnostics.

### Description
- Added a new CLI-only mode `--show-excel-remediation-summary` in `tools/migration/csv_mysql_dry_run_importer.php` that runs the existing required-field diagnostics and then prints grouped Excel/CSV remediation guidance (identity/linkage, likely-new insert readiness, frontend-readiness, accessibility/content, governance decisions) plus a model_id duplicate reminder (`nike_female_leggings x 2`).
- Updated `--help` and `--status` text to document the new mode and to declare that the Excel remediation summary is implemented and remains console-only with no writes, no DB connection, and no SQL execution. 
- Kept all existing safe modes/behaviors unchanged and strictly enforced write/execution flag rejection and non-implementation of `--dry-run`/`--execute` while adding the new option to recognized argument parsing and dispatch.

### Testing
- Ran `php -l tools/migration/csv_mysql_dry_run_importer.php` and the file lint check passed with no syntax errors. (pass)
- Ran `php tools/migration/csv_mysql_dry_run_importer.php --show-excel-remediation-summary` which exited `0` and printed the required CSV path, counts, remediation groups and suggested Excel/CSV actions (pass).
- Verified existing modes `--show-frontend-readiness-summary`, `--show-remediation-guidance`, `--check-required-fields`, and `--check-csv-baseline` still run and produce output as before (all passed).
- Verified error/exit behavior: `--dry-run` and `--execute` exit non-zero as expected, and an unknown option (e.g. `--unknown-option`) exits non-zero; `--help` and `--status` exit `0` (behaviors preserved).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1009f4746483249e46d2cdae04f888)