### PR TITLE
docs: clarify local vs future database terminology in DBeaver import docs

### DIFF
--- a/README/V-AUDIT/POST-AUDIT/2026-05-23-CSV-Diagnostic-Framework-Retrospective.md
+++ b/README/V-AUDIT/POST-AUDIT/2026-05-23-CSV-Diagnostic-Framework-Retrospective.md
@@ -8,7 +8,11 @@ Its purpose is to decide what was worthwhile, what was excessive, and how to avo
 
 ## 2. Original operational goal
 
-The original operational goal was simple: copy and import the newly structured Excel and CSV product database into the online MySQL database through DBeaver.
+Current phase: local DBeaver/Laragon MySQL staging import into `localhost:3306` / `sportswh`.
+
+Future phase: possible online/cloud-hosted deployment or migration after local staging/import is verified. Cloudways is currently discontinued due to cost and is not part of this immediate workflow.
+
+The original operational goal was simple: copy and import the newly structured Excel and CSV product database into the local DBeaver/Laragon MySQL database (`localhost:3306`, schema `sportswh`) through DBeaver.
 
 In a humble workflow, this might have been completed in a day through manual paste or a straightforward CSV import.
 
@@ -123,7 +127,7 @@ The project now has enough diagnostic evidence to move toward DBeaver staging an
 
 Before live update or insert, these items still require careful handling:
 
-- exact online schema confirmation
+- exact local schema confirmation (`localhost:3306` / `sportswh`)
 - staging table versus direct target table decision
 - backup and rollback plan
 - column mapping validation

--- a/README/V-AUDIT/POST-AUDIT/2026-05-23-DBeaver-CSV-to-MySQL-Import-Runbook.md
+++ b/README/V-AUDIT/POST-AUDIT/2026-05-23-DBeaver-CSV-to-MySQL-Import-Runbook.md
@@ -2,13 +2,17 @@
 
 ## 1. Purpose
 
-This runbook defines a practical DBeaver-based operational path for copying/importing Sports Warehouse CSV product data into the online MySQL database.
+This runbook defines a practical DBeaver-based operational path for copying/importing Sports Warehouse CSV product data into the local DBeaver/Laragon MySQL database (`localhost:3306`, schema `sportswh`).
 
 The immediate goal is no longer to default to additional diagnostics and reporting. The goal is to move toward controlled import/copy execution with explicit safety checks.
 
 This document is documentation-only guidance. It does not perform any import, copy, update, insert, or publish action.
 
 ## 2. Current verified state
+
+Current phase: local DBeaver/Laragon MySQL staging import into `localhost:3306` / `sportswh`.
+
+Future phase: possible online/cloud-hosted deployment or migration after local staging/import is verified.
 
 The current verified CSV and workflow state is:
 
@@ -72,7 +76,7 @@ Benefits:
 
 Before any DBeaver import/copy operation:
 
-- Confirm online database connection works in DBeaver.
+- Confirm local DBeaver connection works (`localhost:3306`, schema `sportswh`).
 - Confirm target database/schema name.
 - Confirm backup or restore point exists.
 - Confirm current live item/product table schema.
@@ -189,7 +193,7 @@ No frontend gating implementation is performed in this task.
 Practical DBeaver runbook outline (no executed operation here):
 
 1. Open DBeaver.
-2. Connect to the online MySQL database.
+2. Connect to the local MySQL database (`localhost:3306`, schema `sportswh`).
 3. Select the target database/schema.
 4. Start Data Import / Import Data from CSV.
 5. Choose source CSV file: `docs/data/SportWarehouse_ProductDB.csv`.

--- a/README/V-AUDIT/POST-AUDIT/2026-05-23-DBeaver-Staging-Table-Mapping-Checklist.md
+++ b/README/V-AUDIT/POST-AUDIT/2026-05-23-DBeaver-Staging-Table-Mapping-Checklist.md
@@ -8,6 +8,10 @@ This is not another diagnostic expansion. It is a practical mapping aid for stag
 
 ## 2. Scope
 
+Current phase: local DBeaver/Laragon MySQL staging import into `localhost:3306` / `sportswh`.
+
+Future phase: possible online/cloud-hosted deployment or migration after local staging/import is verified.
+
 This document is documentation-only and defines planning and mapping guidance only.
 
 - documentation-only
@@ -50,7 +54,7 @@ Import the CSV as source data into staging only. Do not treat CSV presence as pe
 ## 6. Minimal DBeaver import checklist
 
 - [ ] open DBeaver
-- [ ] connect to online MySQL database
+- [ ] connect to local MySQL database (`localhost:3306`, schema `sportswh`)
 - [ ] confirm database/schema
 - [ ] confirm backup/restore point
 - [ ] select CSV import/data transfer workflow
@@ -164,7 +168,7 @@ Frontend publication requires a separate future gating/publish decision.
 Proceed to DBeaver staging import once all of the following are true:
 
 - staging table name is confirmed
-- online database/schema is confirmed
+- local database/schema (`sportswh`) is confirmed
 - backup/rollback exists
 - CSV header mapping is reviewed
 - import target is staging only
@@ -207,7 +211,7 @@ Proceed to DBeaver staging import once all of the following are true:
 
 After this checklist is reviewed, the immediate next step is a human-guided DBeaver staging import preparation step:
 
-- confirm online DB/schema
+- confirm local DB/schema (`localhost:3306` / `sportswh`)
 - confirm staging table name
 - decide whether DBeaver will create the staging table from CSV or import into a pre-created staging table
 - then perform the staging import carefully


### PR DESCRIPTION
### Motivation
- Correct misleading phrasing that implied the current CSV/DBeaver import target was an online/Cloudways/production database instead of the local DBeaver/Laragon MySQL instance (`localhost:3306`, schema `sportswh`).
- Preserve the original staging-first operational policy while making the current vs future phases explicit. 

### Description
- Updated three README files under `README/V-AUDIT/POST-AUDIT` to replace current-phase wording that referenced an "online" or "production" DB with explicit local-target wording (`local DBeaver/Laragon MySQL database`, `localhost:3306`, `sportswh`).
- Inserted concise `Current phase` and `Future phase` clarification blocks in the three targeted documents to distinguish local staging import from any future cloud-hosted deployment and noted that Cloudways is discontinued for now.
- Adjusted actionable checklist and runbook steps to say `connect to local MySQL database (localhost:3306, schema sportswh)` and similar local confirmations in place of prior "online" references. 
- No code, CSV, importer, DB, generated-report, UI, route, or image changes were made; all edits are documentation-only and narrowly targeted. 

### Testing
- Ran `git diff --check` and found no whitespace/format issues. (passed)
- Ran targeted term searches with `rg` to confirm remaining matches are only historical or explicitly future-phase references. (passed)
- Performed an ASCII byte-scan of the changed markdown files to verify ASCII-safe punctuation. (passed)
- Reviewed the changed files (`README/V-AUDIT/POST-AUDIT/2026-05-23-DBeaver-CSV-to-MySQL-Import-Runbook.md`, `README/V-AUDIT/POST-AUDIT/2026-05-23-DBeaver-Staging-Table-Mapping-Checklist.md`, `README/V-AUDIT/POST-AUDIT/2026-05-23-CSV-Diagnostic-Framework-Retrospective.md`) to confirm wording updates and that the staging-first policy and non-goals remain intact. (passed)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1123f3874c8324a91a3653597892e2)