### PR TITLE
Document intentional blank subCategoryParent Set component exceptions

### DIFF
--- a/docs/data/Dropdowns-taxonomy-model.md
+++ b/docs/data/Dropdowns-taxonomy-model.md
@@ -30,3 +30,22 @@ Purpose: validation/mapping helper that maps each `subCategory` (product type) t
 ## Scope note
 
 This documentation update renames the taxonomy helper field from `parentCategory` to `subCategoryParent` in CSV/import/staging documentation contexts only. It does not change live database tables or frontend publication behavior.
+
+## Intentional blank `subCategoryParent` exception rule
+
+Normally, `subCategoryParent` is expected to be populated from the Dropdowns `subCategory` -> `subCategoryParent` mapping for each product row.
+
+A narrow exception is allowed for **known Set component rows** where:
+
+- `categoryName = Set` is being used to describe the row's bundle/grouping context, and
+- `subCategory` still describes the component’s intrinsic product type (for example `T_Shirt`, `Kid_Shoes`, `Backpack`).
+
+In this exception case, `subCategoryParent` may be intentionally left blank **only when explicitly documented as a known Set component exception**.
+
+Current known intentional blank `subCategoryParent` exceptions:
+
+1. `Adidas | Marvel Spider-Man: T-Shirt` (`categoryName=Set`, `subCategory=T_Shirt`)
+2. `Adidas | Marvel Spider-Man: Light-Up Trainers` (`categoryName=Set`, `subCategory=Kid_Shoes`)
+3. `Adidas | Marvel Spider-Man: Backpack` (`categoryName=Set`, `subCategory=Backpack`)
+
+Concise rule: **Blank `subCategoryParent` values should be explained. They are acceptable only when documented as known Set component exceptions; otherwise they require review.**

--- a/docs/operations/generated/csv-taxonomy-fill-review.md
+++ b/docs/operations/generated/csv-taxonomy-fill-review.md
@@ -3,7 +3,9 @@
 - categoryName filled: 66
 - subCategoryParent filled: 117
 - subCategory filled: 0
-- suspicious rows flagged: 3
+- suspicious rows flagged: 0
+- blank_subCategoryParent_known_set_component_exceptions: 3
+- blank_subCategoryParent_unexplained: 0
 
 ## Rows changed
 - line 2: subCategory=Tracksuit -> categoryName=Set, subCategoryParent=Set
@@ -127,10 +129,17 @@
 ## Rows left unresolved
 - none
 
-## categoryName/subCategoryParent disagreements
-- line 3: subCategory=T_Shirt, categoryName=Set, subCategoryParent= (categoryName disagrees with mapping Tops)
-- line 4: subCategory=Kid_Shoes, categoryName=Set, subCategoryParent= (categoryName disagrees with mapping Shoes)
-- line 5: subCategory=Backpack, categoryName=Set, subCategoryParent= (categoryName disagrees with mapping Equipment)
+## categoryName/subCategoryParent documented Set component exceptions
+- line 3: Adidas | Marvel Spider-Man: T-Shirt -> categoryName=Set, subCategory=T_Shirt, subCategoryParent blank (known Set component exception; intrinsic mapping parent would be Tops)
+- line 4: Adidas | Marvel Spider-Man: Light-Up Trainers -> categoryName=Set, subCategory=Kid_Shoes, subCategoryParent blank (known Set component exception; intrinsic mapping parent would be Shoes)
+- line 5: Adidas | Marvel Spider-Man: Backpack -> categoryName=Set, subCategory=Backpack, subCategoryParent blank (known Set component exception; intrinsic mapping parent would be Equipment)
 
 ## Skipped inference
 - none
+
+
+## Validation checklist wording
+- Track `blank_subCategoryParent_known_set_component_exceptions` separately from `blank_subCategoryParent_unexplained`.
+- `blank_subCategoryParent_known_set_component_exceptions` is acceptable only for explicitly documented Set component rows.
+- `blank_subCategoryParent_unexplained` must be treated as requiring review.
+- Rule: blank `subCategoryParent` values must always be explained; unexplained blanks are not auto-accepted.


### PR DESCRIPTION
### Motivation
- Clarify why a small number of product-import rows have blank `subCategoryParent` values so they are not treated as unexplained data quality issues in future CSV/import/staging reviews. 
- Record an explicit, narrow exception policy for `categoryName = Set` component rows where the row uses `Set` as a bundle/grouping context and the component’s intrinsic `subCategory` remains the authoritative product type. 
- Ensure validation/checklist outputs and generated review summaries distinguish known documented exceptions from unexplained blanks without changing runtime code, DB schema, or CSV data values. 

### Description
- Added an "Intentional blank `subCategoryParent` exception rule" section to `docs/data/Dropdowns-taxonomy-model.md` that explains normal derivation of `subCategoryParent`, the narrow Set-component exception, and the concise acceptance rule that blank `subCategoryParent` values must be explained. 
- Documented the three current Marvel Spider-Man component rows as the known intentional blank `subCategoryParent` exceptions in the taxonomy doc: the T-Shirt, Light-Up Trainers, and Backpack rows. 
- Updated `docs/operations/generated/csv-taxonomy-fill-review.md` to classify blanks with `blank_subCategoryParent_known_set_component_exceptions: 3` and `blank_subCategoryParent_unexplained: 0`, and to replace the former disagreement list with a documented-exceptions section describing the three rows. 
- Appended validation/checklist wording to the generated review so completeness checks explicitly track `blank_subCategoryParent_known_set_component_exceptions` separately from `blank_subCategoryParent_unexplained` and state that unexplained blanks require review. 

### Testing
- Verified the CSV row count with a small Python check: `docs/data/SportWarehouse_ProductDB.csv` remains at 121 total lines / 120 data rows. (succeeded) 
- Searched repository docs for relevant strings using `rg` to confirm the new wording appears in `docs/data/Dropdowns-taxonomy-model.md` and `docs/operations/generated/csv-taxonomy-fill-review.md`. (succeeded) 
- Printed the updated files with `sed` / `nl` to review the inserted sections and counts and confirmed the three Marvel Spider-Man rows are now documented as exceptions. (succeeded) 
- Committed the documentation changes and confirmed no PHP runtime, SQL schema, importer implementation, frontend files, or live table definitions were modified by this PR. (succeeded)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1231b15f9c83248fd50855bd43d6da)