### PR TITLE
Refresh image-sync reconciliation docs for subCategoryParent taxonomy and pending products

### DIFF
--- a/docs/operations/generated/image-sync-reconciliation-report.csv
+++ b/docs/operations/generated/image-sync-reconciliation-report.csv
@@ -1,0 +1,4 @@
+classification,total_rows,brand,rows,notes
+new_products_pending_database_reconciliation,66,Ryderwear,62,"Newer products added after previous local MySQL website import; pending controlled DB insertion/reconciliation before db_itemId/image linkage."
+new_products_pending_database_reconciliation,66,Adidas,4,"Newer products added after previous local MySQL website import; pending controlled DB insertion/reconciliation before db_itemId/image linkage."
+legacy_database_coverage,54,ALL,54,"Items present in prior active MySQL baseline used for reconciliation comparisons."

--- a/docs/operations/generated/image-sync-reconciliation-summary.md
+++ b/docs/operations/generated/image-sync-reconciliation-summary.md
@@ -1,0 +1,57 @@
+# Image Sync Reconciliation Summary
+
+Generated: 2026-05-23 (UTC)
+
+## Scope
+This report documents **CSV-vs-local-database image-sync reconciliation status** after the taxonomy rename from `parentCategory` to `subCategoryParent` (PR #134 context) and after re-importing local `product_import_staging` from `docs/data/SportWarehouse_ProductDB.csv`.
+
+## Current CSV Header Model
+Detected headers include current taxonomy fields:
+- `categoryName`
+- `subCategory`
+- `subCategoryParent` ✅ current header
+
+Legacy note:
+- `parentCategory` is a legacy name and is **not** a current CSV header.
+
+## Current Row Counts
+- Total CSV rows: **120**
+- Total active MySQL items considered (prior local import baseline): **54**
+- `csv_future_or_staging`: **66**
+- `csv_only_candidate`: **8**
+- `mysql_stale_relative_to_csv`: **46**
+- `mysql_only_legacy`: **16**
+
+Staging completeness checks:
+- Missing `db_itemId`: **66**
+- Missing images: **66**
+- Missing `categoryName`: **0**
+- Missing `subCategory`: **0**
+- Blank `subCategoryParent` known Set component exceptions: **3**
+- Blank `subCategoryParent` unexplained: **0**
+
+## Classification Update (Important)
+The 66 rows with blank `db_itemId` and blank images are now explicitly classified as:
+
+- **`new_products_pending_database_reconciliation`**
+
+These are **not unexplained import errors**. They are newer catalog rows introduced after the prior local website database snapshot.
+
+### Pending Distribution
+- **Ryderwear:** 62 rows pending database/image reconciliation
+- **Adidas:** 4 rows pending database/image reconciliation
+
+## Workflow Interpretation (Separated Concerns)
+To avoid conflating readiness states, keep these tracks separate:
+
+1. **Taxonomy remediation**
+   - Ensure taxonomy columns are populated and aligned to current header names (`subCategoryParent`, not `parentCategory`).
+2. **Image/path reconciliation**
+   - Validate image/path fields only for rows already represented in database-backed workflows.
+3. **Database insertion/reconciliation**
+   - Controlled insertion/mapping is required for `new_products_pending_database_reconciliation` rows before assigning `db_itemId` and image linkage.
+4. **Frontend publication readiness**
+   - Rows should be treated as database-backed frontend products only after successful insertion/reconciliation and downstream validation.
+
+## Next-Step Control Gate
+The 66 pending rows require a later, controlled **database insertion/reconciliation workflow** before they should be interpreted as normal missing-data defects or published as frontend-ready database-backed products.


### PR DESCRIPTION
### Motivation
- Align generated image-sync reconciliation documentation to the CSV taxonomy rename from `parentCategory` to `subCategoryParent` and avoid stale terminology.
- Reclassify rows with blank `db_itemId`/image fields so they are treated as intentionally newer catalog entries rather than unexplained import defects.
- Make the reconciliation outputs explicit about the 66 staging rows that require controlled database insertion before they become frontend-ready products.

### Description
- Added `docs/operations/generated/image-sync-reconciliation-summary.md` that documents the current CSV header model (using `subCategoryParent`), row counts, and a new classification `new_products_pending_database_reconciliation` with rationale.
- Added `docs/operations/generated/image-sync-reconciliation-report.csv` that enumerates the `new_products_pending_database_reconciliation` rows and the split by brand (`Ryderwear` 62, `Adidas` 4) alongside the legacy database coverage row.
- Clarified workflow separation between taxonomy remediation, image/path reconciliation, database insertion/reconciliation, and frontend publication readiness without changing any importer/runtime/database/frontend code or CSV content.
- Preserved source CSV `docs/data/SportWarehouse_ProductDB.csv` unchanged and did not assign `db_itemId` values or invent image paths.

### Testing
- Ran a Python CSV validation script to confirm `docs/data/SportWarehouse_ProductDB.csv` has 120 rows, contains `subCategoryParent` and not `parentCategory`, and that the 66 pending rows break down by brand as `Ryderwear: 62` and `Adidas: 4`, and this check succeeded when executed via the repository environment.
- Computed a SHA256 of `docs/data/SportWarehouse_ProductDB.csv` to ensure the CSV content was not modified, and the checksum verification succeeded.
- Searched the generated summary and report for legacy header usage and the new classification using `rg`, confirming the files reference `subCategoryParent` (not `parentCategory`) and include `new_products_pending_database_reconciliation` and the brand counts.
- Verified that only the two generated documentation files (`docs/operations/generated/image-sync-reconciliation-summary.md` and `docs/operations/generated/image-sync-reconciliation-report.csv`) were added/changed and no PHP, importer, schema, frontend, or runtime files were altered.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1236aa31c483248795056f3ea66e9d)