### PR TITLE
docs: add pending product readiness verification for 66 pending rows

### DIFF
--- a/docs/operations/generated/pending-product-readiness-verification.md
+++ b/docs/operations/generated/pending-product-readiness-verification.md
@@ -1,0 +1,137 @@
+# Pending Product Readiness Verification (Publication Gating)
+
+Generated: 2026-05-23 (UTC)
+
+## Purpose
+This document records a **documentation-only, read-only verification** of publication readiness for the **66 pending rows** currently classified as `new_products_pending_database_reconciliation`.
+
+This report does not modify product data and does not perform any database write, `db_itemId` assignment, or image-path assignment.
+
+## Scope and Context
+- Reconciliation context remains documented in `docs/operations/generated/pending-product-db-reconciliation-plan.md`.
+- Taxonomy remediation is already resolved and documented separately.
+- This report covers **frontend publication readiness gates** for pending rows, distinct from taxonomy completion and distinct from later database insertion execution.
+
+## Read-Only Verification Inputs
+Current local baseline observed during DBeaver read-only checks:
+- Active product table: `item`
+- `item` row count: 54
+- `item.itemId` range: 70–123
+- `item.db_itemId` numeric range: 1–54
+- Existing active brand coverage includes Adidas (14 rows) and no Ryderwear rows.
+
+Current pending scope in `product_import_staging`:
+- Adidas: 4
+- Ryderwear: 62
+- Total: 66
+
+## Duplicate Collision Result
+Duplicate collision check of pending rows against existing `item` rows by `brand + itemName` returned **no rows**.
+
+Interpretation:
+- There is no detected name-level collision blocking pending-row onboarding at this time.
+- This does **not** imply publication readiness; required content and assignment fields still block publication.
+
+## Pending Distribution by Brand / Category
+- Adidas | Pants | Pants: 2
+- Adidas | Tops | Tops: 2
+- Ryderwear | Equipment | Equipment: 1
+- Ryderwear | Pants | Pants: 26
+- Ryderwear | Set | Set: 2
+- Ryderwear | Tops | Tops: 33
+
+Total verified pending rows across groups: 66.
+
+## Ryderwear Collection / SubCategory Grouping (62 Rows)
+- Activate | Tops | Sports_Bra: 1
+- Contour | Pants | Leggings: 1
+- Contour | Pants | Shorts: 1
+- Contour | Pants | Track_Pants: 1
+- Contour | Tops | Sports_Bra: 1
+- Empower | Pants | Leggings: 1
+- Empower | Pants | Shorts: 1
+- Empower | Tops | Sports_Bra: 2
+- Honeycomb | Pants | Leggings: 1
+- Honeycomb | Pants | Shorts: 1
+- Honeycomb | Tops | Sports_Bra: 1
+- Icon | Pants | Leggings: 1
+- Icon | Pants | Shorts: 1
+- Icon | Tops | Sports_Bra: 2
+- Lift_2_0 | Pants | Leggings: 1
+- Lift_2_0 | Pants | Shorts: 1
+- Lift_2_0 | Tops | Sports_Bra: 1
+- Logo Lux | Tops | Sports_Bra: 1
+- Momentum | Tops | Sports_Bra: 1
+- NKD | Pants | Leggings: 4
+- NKD | Pants | Shorts: 2
+- NKD | Set | Bodysuit: 2
+- NKD | Tops | Long_Sleeve: 1
+- NKD | Tops | Sports_Bra: 8
+- NKD | Tops | T_Shirt: 1
+- NKD | Tops | Tank_Top: 2
+- NULL collection | Equipment | Gym_Bag: 1
+- NULL collection | Tops | Slouchy_Off_Shoulder_Top: 1
+- Persist | Pants | Shorts: 1
+- Replay | Pants | Leggings: 1
+- Replay | Tops | Sports_Bra: 1
+- Rib_Seamless | Pants | Leggings: 1
+- Rib_Seamless | Pants | Shorts: 1
+- Rib_Seamless | Tops | Sports_Bra: 2
+- Rib_Seamless | Tops | T_Shirt: 1
+- Sculpt | Pants | Leggings: 1
+- Sculpt | Pants | Shorts: 1
+- Sculpt | Tops | Sports_Bra: 1
+- Staples | Pants | Shorts: 1
+- Stonewash | Pants | Leggings: 1
+- Stonewash | Pants | Shorts: 1
+- Stonewash | Tops | Sports_Bra: 1
+- Terry Towelling | Tops | Sports_Bra: 1
+- Ultra | Tops | T_Shirt: 1
+- Ultra | Tops | Tank_Top: 2
+
+## Readiness Blockers by Brand
+### Adidas (4 pending rows)
+- Missing `price`: 4
+- Missing `salePrice`: 4
+- Missing `description`: 4
+- Missing `altText`: 4
+- Missing `ariaText`: 4
+- Missing `assignment_source`: 4
+
+### Ryderwear (62 pending rows)
+- Missing `price`: 62
+- Missing `salePrice`: 62
+- Missing `description`: 59
+- Missing `altText`: 62
+- Missing `ariaText`: 62
+- Missing `assignment_source`: 62
+
+### Additional reconciliation dependencies (tracked elsewhere)
+For this same pending scope, `db_itemId` and images/image paths remain part of the separate database reconciliation and image reconciliation workflows already documented in generated operations docs.
+
+## Publication Readiness Determination
+These 66 pending rows are **not yet ready** for database-backed frontend publication.
+
+Reason:
+- Required commercial, accessibility/content, and assignment-traceability fields are incomplete at scale.
+- `db_itemId` and image/image-path readiness are still tracked as unresolved reconciliation dependencies.
+
+## Distinction from Taxonomy Remediation
+Taxonomy remediation is considered resolved/documented and is **not** the current blocker.
+
+The active blocker category is publication-readiness completeness (content + assignment + reconciliation dependencies), which is a separate decision track from taxonomy.
+
+## Next Workflow Decision (Policy Needed)
+The next workflow decision is field ownership and completion policy across source vs downstream systems:
+
+1. Which required fields must be completed in Excel/CSV before import/reconciliation.
+2. Which fields may be completed later in admin/backend workflows.
+3. Whether non-publishable seed rows are allowed in the database before full content readiness.
+
+No policy decision is made in this report; this report only records the current readiness state.
+
+## Explicit Constraints Observed in This Verification
+- No `db_itemId` values assigned.
+- No image paths invented.
+- No product data changed.
+- No runtime, frontend, importer, PHP, or schema changes performed.


### PR DESCRIPTION
### Motivation
- Provide a documentation-only, read-only verification of frontend publication readiness for the 66 rows classified as `new_products_pending_database_reconciliation` so execution is deferred until policy and content gaps are resolved. 
- Record that duplicate collision checks against existing `item` rows by `brand + itemName` returned no rows while preserving the distinction between database reconciliation and frontend publication readiness. 
- Capture the pending distribution by brand/category and the detailed Ryderwear collection/subCategory grouping to inform controlled insertion and content-completion decisions. 
- Surface the remaining readiness blockers (commercial fields, content/accessibility text, `assignment_source`, and separate `db_itemId`/image reconciliation) and document the next workflow policy decision points for field ownership/completion.

### Description
- Adds a new documentation-only report at `docs/operations/generated/pending-product-readiness-verification.md` that summarizes read-only DBeaver observations, pending distribution (Adidas 4, Ryderwear 62), Ryderwear collection/subCategory breakdown, duplicate-collision result, readiness blockers by brand, and next-policy questions. 
- Explicitly documents guardrails: no `db_itemId` assignments, no image-path invention, no product data changes, and no PHP/runtime/importer/database schema modifications. 
- Keeps this report distinct from taxonomy remediation and from the separate reconciliation plan already present in `docs/operations/generated/pending-product-db-reconciliation-plan.md`. 
- Only the new markdown report file was added; no other repository files (including `docs/data/SportWarehouse_ProductDB.csv`, PHP, schema, importer, or frontend/runtime files) were modified.

### Testing
- Ran read-only content inspections of existing reconciliation docs with `sed -n '1,220p' docs/operations/generated/pending-product-db-reconciliation-plan.md` and confirmed context (succeeded). 
- Verified repository state and that `docs/data/SportWarehouse_ProductDB.csv` is unchanged with `git status --short && git diff -- docs/data/SportWarehouse_ProductDB.csv && git diff --name-only` and observed only the new doc file (succeeded). 
- Inspected the new report content with `nl -ba docs/operations/generated/pending-product-readiness-verification.md | sed -n '1,260p'` to confirm the recorded distributions and readiness blockers (succeeded). 
- Added and recorded the new file to the repository (commit completed) as a documentation-only change (succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a123de44ef483248018bb9faeb9b0be)