### PR TITLE
Add Ryderwear Contour inactive pilot insert SQL script

### DIFF
--- a/docs/operations/generated/sql/ryderwear-contour-inactive-pilot-insert.sql
+++ b/docs/operations/generated/sql/ryderwear-contour-inactive-pilot-insert.sql
@@ -1,0 +1,323 @@
+-- Local-only controlled inactive pilot insert script
+-- Target DB: sportswh (MySQL)
+-- Scope: Insert only 4 Ryderwear Contour pending rows from product_import_staging into item as inactive records
+-- IMPORTANT: Review preflight checks before running INSERT.
+
+USE sportswh;
+
+-- =========================================================
+-- 1) READ-ONLY PREFLIGHT CHECKS
+-- =========================================================
+
+-- 1a) Confirm the 4 target staging rows exist
+SELECT
+    pis.brand,
+    pis.itemName,
+    pis.categoryName,
+    pis.subCategory,
+    pis.subCategoryParent,
+    pis.model_id,
+    pis.db_itemId,
+    pis.images
+FROM product_import_staging pis
+WHERE pis.brand = 'Ryderwear'
+  AND pis.itemName IN (
+      'Contour Halter Sports Bra',
+      'Contour Seamless High-Waisted Leggings',
+      'Contour Seamless High-Waisted Shorts',
+      'Contour Track Pants'
+  )
+ORDER BY FIELD(
+    pis.itemName,
+    'Contour Halter Sports Bra',
+    'Contour Seamless High-Waisted Leggings',
+    'Contour Seamless High-Waisted Shorts',
+    'Contour Track Pants'
+);
+
+-- 1b) Confirm all 4 have model_id
+SELECT
+    pis.itemName,
+    pis.model_id,
+    CASE
+        WHEN pis.model_id IS NULL OR TRIM(pis.model_id) = '' THEN 'MISSING_MODEL_ID'
+        ELSE 'OK'
+    END AS model_id_status
+FROM product_import_staging pis
+WHERE pis.brand = 'Ryderwear'
+  AND pis.itemName IN (
+      'Contour Halter Sports Bra',
+      'Contour Seamless High-Waisted Leggings',
+      'Contour Seamless High-Waisted Shorts',
+      'Contour Track Pants'
+  )
+ORDER BY FIELD(
+    pis.itemName,
+    'Contour Halter Sports Bra',
+    'Contour Seamless High-Waisted Leggings',
+    'Contour Seamless High-Waisted Shorts',
+    'Contour Track Pants'
+);
+
+-- 1c) Confirm no model_id collides with item.external_item_id
+SELECT
+    pis.itemName,
+    pis.model_id,
+    i.itemId AS colliding_itemId,
+    i.external_item_id AS colliding_external_item_id
+FROM product_import_staging pis
+JOIN item i
+    ON i.external_item_id = pis.model_id
+WHERE pis.brand = 'Ryderwear'
+  AND pis.itemName IN (
+      'Contour Halter Sports Bra',
+      'Contour Seamless High-Waisted Leggings',
+      'Contour Seamless High-Waisted Shorts',
+      'Contour Track Pants'
+  );
+-- Expectation: 0 rows
+
+-- 1d) Confirm no brand + itemName collision with existing item rows
+SELECT
+    pis.brand,
+    pis.itemName,
+    i.itemId AS colliding_itemId,
+    i.brand AS existing_brand,
+    i.itemName AS existing_itemName
+FROM product_import_staging pis
+JOIN item i
+    ON i.brand = pis.brand
+   AND i.itemName = pis.itemName
+WHERE pis.brand = 'Ryderwear'
+  AND pis.itemName IN (
+      'Contour Halter Sports Bra',
+      'Contour Seamless High-Waisted Leggings',
+      'Contour Seamless High-Waisted Shorts',
+      'Contour Track Pants'
+  );
+-- Expectation: 0 rows
+
+-- 1e) Confirm current MAX(db_itemId)
+SELECT MAX(db_itemId) AS current_max_db_itemId FROM item;
+-- Expectation from current reconciliation notes: 54
+
+-- 1f) Confirm categoryId mapping for Tops/Pants
+SELECT c.categoryId, c.categoryName
+FROM category c
+WHERE c.categoryName IN ('Tops', 'Pants')
+ORDER BY c.categoryId;
+-- Expected: Tops=1, Pants=2
+
+
+-- =========================================================
+-- 2) BACKUP TABLE (GUARDED)
+-- =========================================================
+
+-- Guard: fail-safe check to ensure backup table does not already exist
+SELECT
+    CASE
+        WHEN EXISTS (
+            SELECT 1
+            FROM information_schema.tables t
+            WHERE t.table_schema = DATABASE()
+              AND t.table_name = 'item_backup_before_ryderwear_contour_pilot'
+        ) THEN 'ERROR_BACKUP_TABLE_ALREADY_EXISTS'
+        ELSE 'OK_TO_CREATE_BACKUP'
+    END AS backup_table_guard_status;
+
+-- Create one-time backup snapshot (run only when guard status = OK_TO_CREATE_BACKUP)
+CREATE TABLE IF NOT EXISTS item_backup_before_ryderwear_contour_pilot AS
+SELECT *
+FROM item;
+
+
+-- =========================================================
+-- 3) CONTROLLED INSERT (4 ROWS ONLY, INACTIVE)
+-- =========================================================
+
+-- Stable deterministic ordering for db_itemId assignment:
+--   55 -> Contour Halter Sports Bra
+--   56 -> Contour Seamless High-Waisted Leggings
+--   57 -> Contour Seamless High-Waisted Shorts
+--   58 -> Contour Track Pants
+
+INSERT INTO item (
+    itemName,
+    categoryId,
+    categoryName,
+    parentCategory,
+    subcategory,
+    price,
+    salePrice,
+    description,
+    images,
+    altText,
+    ariaText,
+    brand,
+    featured,
+    assignment_source,
+    external_item_id,
+    db_itemId,
+    is_active
+)
+SELECT
+    pis.itemName,
+    CASE
+        WHEN pis.categoryName = 'Tops' THEN 1
+        WHEN pis.categoryName = 'Pants' THEN 2
+        WHEN pis.categoryName = 'Set' THEN 4
+        WHEN pis.categoryName = 'Equipment' THEN 8
+        ELSE NULL
+    END AS categoryId,
+    pis.categoryName,
+    pis.subCategoryParent AS parentCategory,
+    pis.subCategory AS subcategory,
+    NULLIF(TRIM(pis.price), '') AS price,
+    NULLIF(TRIM(pis.salePrice), '') AS salePrice,
+    NULLIF(TRIM(pis.description), '') AS description,
+    NULLIF(TRIM(pis.images), '') AS images,
+    NULLIF(TRIM(pis.altText), '') AS altText,
+    NULLIF(TRIM(pis.ariaText), '') AS ariaText,
+    pis.brand,
+    0 AS featured,
+    'custom' AS assignment_source,
+    pis.model_id AS external_item_id,
+    CASE pis.itemName
+        WHEN 'Contour Halter Sports Bra' THEN 55
+        WHEN 'Contour Seamless High-Waisted Leggings' THEN 56
+        WHEN 'Contour Seamless High-Waisted Shorts' THEN 57
+        WHEN 'Contour Track Pants' THEN 58
+    END AS db_itemId,
+    0 AS is_active
+FROM product_import_staging pis
+WHERE pis.brand = 'Ryderwear'
+  AND pis.itemName IN (
+      'Contour Halter Sports Bra',
+      'Contour Seamless High-Waisted Leggings',
+      'Contour Seamless High-Waisted Shorts',
+      'Contour Track Pants'
+  )
+  AND (pis.db_itemId IS NULL OR TRIM(pis.db_itemId) = '')
+  AND (pis.images IS NULL OR TRIM(pis.images) = '')
+  AND pis.model_id IS NOT NULL
+  AND TRIM(pis.model_id) <> ''
+ORDER BY FIELD(
+    pis.itemName,
+    'Contour Halter Sports Bra',
+    'Contour Seamless High-Waisted Leggings',
+    'Contour Seamless High-Waisted Shorts',
+    'Contour Track Pants'
+);
+
+
+-- =========================================================
+-- 4) POST-INSERT VERIFICATION CHECKS
+-- =========================================================
+
+-- 4a) Show the 4 inserted rows
+SELECT
+    i.itemId,
+    i.db_itemId,
+    i.external_item_id,
+    i.brand,
+    i.itemName,
+    i.categoryId,
+    i.categoryName,
+    i.parentCategory,
+    i.subcategory,
+    i.featured,
+    i.assignment_source,
+    i.is_active
+FROM item i
+WHERE i.external_item_id IN (
+    SELECT pis.model_id
+    FROM product_import_staging pis
+    WHERE pis.brand = 'Ryderwear'
+      AND pis.itemName IN (
+          'Contour Halter Sports Bra',
+          'Contour Seamless High-Waisted Leggings',
+          'Contour Seamless High-Waisted Shorts',
+          'Contour Track Pants'
+      )
+)
+ORDER BY i.db_itemId;
+
+-- 4b) Confirm all inserted pilot rows are inactive
+SELECT
+    i.itemName,
+    i.db_itemId,
+    i.is_active
+FROM item i
+WHERE i.db_itemId BETWEEN 55 AND 58
+ORDER BY i.db_itemId;
+-- Expectation: all is_active = 0
+
+-- 4c) Confirm db_itemId 55-58 are present for this pilot
+SELECT
+    i.db_itemId,
+    i.itemName,
+    i.external_item_id
+FROM item i
+WHERE i.db_itemId BETWEEN 55 AND 58
+ORDER BY i.db_itemId;
+
+-- 4d) Confirm external_item_id populated from model_id
+SELECT
+    i.itemName,
+    i.external_item_id,
+    pis.model_id,
+    CASE
+        WHEN i.external_item_id = pis.model_id THEN 'MATCH'
+        ELSE 'MISMATCH'
+    END AS external_id_match_status
+FROM item i
+JOIN product_import_staging pis
+    ON pis.model_id = i.external_item_id
+WHERE pis.brand = 'Ryderwear'
+  AND pis.itemName IN (
+      'Contour Halter Sports Bra',
+      'Contour Seamless High-Waisted Leggings',
+      'Contour Seamless High-Waisted Shorts',
+      'Contour Track Pants'
+  )
+ORDER BY i.db_itemId;
+
+-- 4e) Confirm item count increased by 4 (vs backup snapshot)
+SELECT
+    (SELECT COUNT(*) FROM item_backup_before_ryderwear_contour_pilot) AS item_count_before,
+    (SELECT COUNT(*) FROM item) AS item_count_after,
+    (SELECT COUNT(*) FROM item) - (SELECT COUNT(*) FROM item_backup_before_ryderwear_contour_pilot) AS item_count_delta;
+-- Expectation: item_count_delta = 4
+
+-- 4f) Confirm no duplicate external_item_id
+SELECT
+    i.external_item_id,
+    COUNT(*) AS duplicate_count
+FROM item i
+WHERE i.external_item_id IS NOT NULL
+GROUP BY i.external_item_id
+HAVING COUNT(*) > 1;
+-- Expectation: 0 rows
+
+
+-- =========================================================
+-- 5) ROLLBACK SQL (COMMENTED OUT - DO NOT AUTO-EXECUTE)
+-- =========================================================
+
+-- Option A: Targeted rollback by pilot external_item_id/model_id
+-- DELETE FROM item
+-- WHERE external_item_id IN (
+--     SELECT pis.model_id
+--     FROM product_import_staging pis
+--     WHERE pis.brand = 'Ryderwear'
+--       AND pis.itemName IN (
+--           'Contour Halter Sports Bra',
+--           'Contour Seamless High-Waisted Leggings',
+--           'Contour Seamless High-Waisted Shorts',
+--           'Contour Track Pants'
+--       )
+-- );
+
+-- Option B: Full restore from backup snapshot
+-- TRUNCATE TABLE item;
+-- INSERT INTO item SELECT * FROM item_backup_before_ryderwear_contour_pilot;


### PR DESCRIPTION
### Motivation
- Move from documentation-only planning to a small, controlled local pilot for Ryderwear Contour pending rows. 
- Ensure new rows are inserted as inactive and non-featured to avoid affecting runtime behavior. 
- Provide deterministic db_itemId assignment and guarded backup/rollback paths to make the pilot reversible and auditable.

### Description
- Add a new SQL-only operations script at `docs/operations/generated/sql/ryderwear-contour-inactive-pilot-insert.sql` implementing the controlled inactive pilot. 
- Implement read-only preflight checks that confirm the 4 target staging rows, presence of `model_id`, absence of `model_id`/brand+`itemName` collisions, current `MAX(db_itemId)`, and categoryId mapping. 
- Create a guarded backup snapshot `item_backup_before_ryderwear_contour_pilot` (only created if not present) before any INSERT, and insert the 4 Ryderwear Contour rows from `product_import_staging` with `is_active = 0`, `featured = 0`, `assignment_source = 'custom'`, `external_item_id = model_id`, deterministic `db_itemId` mapping (55–58), taxonomy mapping (categoryName/subCategoryParent -> categoryName/parentCategory), and NULL handling for blank nullable fields. 
- Add post-insert verification queries showing the inserted rows, confirming inactive state, db_itemId 55–58, external_item_id consistency, an item count delta of +4 against the backup snapshot, and duplicate external_id checks, plus clearly commented rollback options (targeted delete or full restore from backup). 

### Testing
- Confirmed the new file exists with `find docs/operations/generated/sql -maxdepth 1 -type f -print`, which returned the expected script path. 
- Previewed the script contents with `nl -ba docs/operations/generated/sql/ryderwear-contour-inactive-pilot-insert.sql` to verify preflight checks, guarded backup, controlled INSERT, post-checks, and commented rollback are present. 
- Verified repository-level checks (`git status`/file listing) to ensure only the new SQL file was added and no CSV/PHP/runtime/importer files were modified; all checks succeeded and the SQL was not executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a12424ef3f88324a50c1be4b8782212)