### PR TITLE
Harden rerun guard for Ryderwear Contour inactive pilot insert SQL

### DIFF
--- a/docs/operations/generated/sql/ryderwear-contour-inactive-pilot-insert.sql
+++ b/docs/operations/generated/sql/ryderwear-contour-inactive-pilot-insert.sql
@@ -113,27 +113,38 @@ ORDER BY c.categoryId;
 -- 2) BACKUP TABLE (GUARDED)
 -- =========================================================
 
--- Guard: fail-safe check to ensure backup table does not already exist
+-- Guard variable: tracks whether backup table existed before this script run
+SET @ryderwear_contour_backup_exists := (
+    SELECT COUNT(*)
+    FROM information_schema.tables t
+    WHERE t.table_schema = DATABASE()
+      AND t.table_name = 'item_backup_before_ryderwear_contour_pilot'
+);
+
 SELECT
     CASE
-        WHEN EXISTS (
-            SELECT 1
-            FROM information_schema.tables t
-            WHERE t.table_schema = DATABASE()
-              AND t.table_name = 'item_backup_before_ryderwear_contour_pilot'
-        ) THEN 'ERROR_BACKUP_TABLE_ALREADY_EXISTS'
-        ELSE 'OK_TO_CREATE_BACKUP'
+        WHEN @ryderwear_contour_backup_exists = 0 THEN 'OK_TO_RUN'
+        ELSE 'STOP_BACKUP_TABLE_ALREADY_EXISTS'
     END AS backup_table_guard_status;
 
--- Create one-time backup snapshot (run only when guard status = OK_TO_CREATE_BACKUP)
+-- Create one-time backup snapshot only when table did not already exist
 CREATE TABLE IF NOT EXISTS item_backup_before_ryderwear_contour_pilot AS
 SELECT *
-FROM item;
+FROM item
+WHERE @ryderwear_contour_backup_exists = 0;
 
 
 -- =========================================================
 -- 3) CONTROLLED INSERT (4 ROWS ONLY, INACTIVE)
 -- =========================================================
+
+-- DO NOT run this insert section unless guard status is OK_TO_RUN.
+-- If guard status is STOP_BACKUP_TABLE_ALREADY_EXISTS, investigate and stop.
+SELECT
+    CASE
+        WHEN @ryderwear_contour_backup_exists = 0 THEN 'OK_TO_RUN'
+        ELSE 'STOP_BACKUP_TABLE_ALREADY_EXISTS'
+    END AS insert_guard_status;
 
 -- Stable deterministic ordering for db_itemId assignment:
 --   55 -> Contour Halter Sports Bra
@@ -201,6 +212,7 @@ WHERE pis.brand = 'Ryderwear'
   AND (pis.images IS NULL OR TRIM(pis.images) = '')
   AND pis.model_id IS NOT NULL
   AND TRIM(pis.model_id) <> ''
+  AND @ryderwear_contour_backup_exists = 0
 ORDER BY FIELD(
     pis.itemName,
     'Contour Halter Sports Bra',


### PR DESCRIPTION
### Motivation
- Prevent accidental re-run or stale-backup execution of the Ryderwear Contour inactive pilot insert by making the backup/insert behavior explicitly guarded.
- Ensure a backup snapshot is only populated when it did not already exist before the script run, and prevent the controlled `INSERT` from running if the backup pre-existed.
- Preserve current safety invariants for the pilot insert such as explicit `is_active = 0` and deterministic `db_itemId` assignment 55–58.

### Description
- Added an executable guard variable `@ryderwear_contour_backup_exists` populated from `information_schema.tables` to detect whether `item_backup_before_ryderwear_contour_pilot` existed before this run. 
- Emit a clear guard status `SELECT` that outputs `OK_TO_RUN` when the backup did not exist and `STOP_BACKUP_TABLE_ALREADY_EXISTS` when it did, and added an `insert_guard_status` `SELECT` and comments instructing operators not to run the insert unless status is `OK_TO_RUN`.
- Kept `CREATE TABLE IF NOT EXISTS` but made the snapshot population conditional by adding `WHERE @ryderwear_contour_backup_exists = 0` so the table is only populated on first run.
- Blocked the controlled `INSERT ... SELECT` by adding `AND @ryderwear_contour_backup_exists = 0` to the `WHERE` clause to prevent insertion when a backup existed prior to this run, and left rollback SQL commented out.
- Confirmed the script still sets `is_active` to `0` and keeps `db_itemId` mapping for the four pilot rows as `55–58`, and only `docs/operations/generated/sql/ryderwear-contour-inactive-pilot-insert.sql` was modified.

### Testing
- Ran repository checks including `git status --short` and pattern searches with `rg` to validate the presence of `@ryderwear_contour_backup_exists`, `insert_guard_status`, `is_active`, and the `db_itemId` mappings, and these checks succeeded.
- Inspected the modified file with `nl -ba docs/operations/generated/sql/ryderwear-contour-inactive-pilot-insert.sql | sed -n '108,230p'` to verify guard logic and insert guard placement, which succeeded.
- Did not execute the SQL against any database (per request) and no runtime SQL tests were performed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1244576044832482d9411565e078b9)