### PR TITLE
Fix item primary-key reference in model_id collision preflight SQL

### DIFF
--- a/docs/operations/generated/sql/widen-item-external-item-id-for-model-id.sql
+++ b/docs/operations/generated/sql/widen-item-external-item-id-for-model-id.sql
@@ -70,7 +70,7 @@ HAVING COUNT(*) > 1;
 -- 1g) Confirm no pending model_id collides with existing item.external_item_id.
 SELECT
   pis.model_id,
-  i.id AS existing_item_id
+  i.itemId AS existing_itemId
 FROM product_import_staging pis
 INNER JOIN item i
   ON i.external_item_id = pis.model_id


### PR DESCRIPTION
### Motivation
- The preflight collision check used the wrong primary-key column (`i.id`) for the local `item` table which would produce incorrect results when detecting pending `model_id` conflicts, so it needs to reference the actual PK `itemId`.

### Description
- Updated `docs/operations/generated/sql/widen-item-external-item-id-for-model-id.sql` to replace `i.id AS existing_item_id` with `i.itemId AS existing_itemId` while leaving the `ALTER TABLE item MODIFY external_item_id VARCHAR(255) DEFAULT NULL;` statement and target width unchanged.

### Testing
- Searched and inspected the modified file to confirm `i.itemId AS existing_itemId` is present, there are no remaining `i.id` references, the `ALTER TABLE item MODIFY external_item_id VARCHAR(255) DEFAULT NULL;` line remains, and only `docs/operations/generated/sql/widen-item-external-item-id-for-model-id.sql` was modified; all checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a124c93d21c8324a152e756e7ee9775)