### PR TITLE
Update Ryderwear Contour inactive pilot insert to use CASE category mapping and note external_item_id widening

### DIFF
--- a/docs/operations/generated/sql/ryderwear-contour-inactive-pilot-insert.sql
+++ b/docs/operations/generated/sql/ryderwear-contour-inactive-pilot-insert.sql
@@ -135,6 +135,8 @@ FROM item;
 -- 3) CONTROLLED INSERT (4 ROWS ONLY, INACTIVE)
 -- =========================================================
 
+-- Prerequisite: item.external_item_id must already be widened to VARCHAR(255)
+-- using docs/operations/generated/sql/widen-item-external-item-id-for-model-id.sql.
 -- Stable deterministic ordering for db_itemId assignment:
 --   55 -> Contour Halter Sports Bra
 --   56 -> Contour Seamless High-Waisted Leggings
@@ -167,7 +169,7 @@ SELECT
         WHEN pis.categoryName = 'Pants' THEN 2
         WHEN pis.categoryName = 'Set' THEN 4
         WHEN pis.categoryName = 'Equipment' THEN 8
-        ELSE NULL
+        ELSE 0
     END AS categoryId,
     pis.categoryName,
     pis.subCategoryParent AS parentCategory,


### PR DESCRIPTION
### Motivation
- Align the controlled Ryderwear Contour inactive INSERT script with the locally validated run which avoided a category join and used inline category mapping, and document the prerequisite widening of `item.external_item_id` to `VARCHAR(255)`.
- Ensure the pilot remains deterministic and inactive while preventing collation/join issues and external_id collisions.

### Description
- Modified only `docs/operations/generated/sql/ryderwear-contour-inactive-pilot-insert.sql` to include a prerequisite comment referencing `docs/operations/generated/sql/widen-item-external-item-id-for-model-id.sql` and to change the `CASE` fallback from `ELSE NULL` to `ELSE 0`.
- The INSERT now uses inline `CASE` mapping for `categoryId` (Tops -> `1`, Pants -> `2`, Set -> `4`, Equipment -> `8`, `ELSE 0`) and contains no `JOIN category` in the INSERT path.
- Preserved the controlled pilot batch, deterministic `db_itemId` mapping (`55`–`58`), `is_active = 0`, `featured = 0`, `assignment_source = 'custom'`, `external_item_id = model_id`, and kept the rollback SQL commented out.

### Testing
- Ran file inspections with `sed -n '1,260p' docs/operations/generated/sql/ryderwear-contour-inactive-pilot-insert.sql` and `sed -n '260,520p' docs/operations/generated/sql/ryderwear-contour-inactive-pilot-insert.sql`, which confirmed the new prerequisite comment and the updated `CASE ... ELSE 0` mapping; these checks succeeded.
- Executed the in-place update script via `python - <<'PY' ...` to apply the change, and re-inspected the file to confirm only the intended modifications; this automated edit succeeded.
- Verified the working tree shows a single changed file and inspected the file diff to confirm there is no `JOIN category` in the INSERT and that `db_itemId` and `is_active` values remain unchanged; these automated verifications succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a125687a0c48324b0e69e2e5239a039)