### PR TITLE
Restore backup/rerun guard in Ryderwear Contour inactive pilot insert

### DIFF
--- a/docs/operations/generated/sql/ryderwear-contour-inactive-pilot-insert.sql
+++ b/docs/operations/generated/sql/ryderwear-contour-inactive-pilot-insert.sql
@@ -114,21 +114,25 @@ ORDER BY c.categoryId;
 -- =========================================================
 
 -- Guard: fail-safe check to ensure backup table does not already exist
+SET @ryderwear_contour_backup_exists := (
+    SELECT COUNT(*)
+    FROM information_schema.tables
+    WHERE table_schema = DATABASE()
+      AND table_name = 'item_backup_before_ryderwear_contour_pilot'
+);
+
+-- Guard status: proceed only when status is OK_TO_RUN
 SELECT
     CASE
-        WHEN EXISTS (
-            SELECT 1
-            FROM information_schema.tables t
-            WHERE t.table_schema = DATABASE()
-              AND t.table_name = 'item_backup_before_ryderwear_contour_pilot'
-        ) THEN 'ERROR_BACKUP_TABLE_ALREADY_EXISTS'
-        ELSE 'OK_TO_CREATE_BACKUP'
-    END AS backup_table_guard_status;
+        WHEN @ryderwear_contour_backup_exists = 0 THEN 'OK_TO_RUN'
+        ELSE 'STOP_BACKUP_TABLE_ALREADY_EXISTS'
+    END AS ryderwear_contour_pilot_guard_status;
 
--- Create one-time backup snapshot (run only when guard status = OK_TO_CREATE_BACKUP)
-CREATE TABLE IF NOT EXISTS item_backup_before_ryderwear_contour_pilot AS
+-- Create one-time backup snapshot only when guard allows run
+CREATE TABLE item_backup_before_ryderwear_contour_pilot AS
 SELECT *
-FROM item;
+FROM item
+WHERE @ryderwear_contour_backup_exists = 0;
 
 
 -- =========================================================
@@ -203,6 +207,7 @@ WHERE pis.brand = 'Ryderwear'
   AND (pis.images IS NULL OR TRIM(pis.images) = '')
   AND pis.model_id IS NOT NULL
   AND TRIM(pis.model_id) <> ''
+  AND @ryderwear_contour_backup_exists = 0
 ORDER BY FIELD(
     pis.itemName,
     'Contour Halter Sports Bra',


### PR DESCRIPTION
### Motivation
- Reinstate a one-time backup/rerun safety guard around the Ryderwear Contour pilot insert to prevent accidental re-runs that would duplicate rows. 
- Preserve the already-validated CASE-based `categoryId` mapping and the insert path that avoids joining the `category` table to prevent collation errors. 

### Description
- Add a session variable `@ryderwear_contour_backup_exists` that counts `item_backup_before_ryderwear_contour_pilot` in `information_schema.tables`. 
- Add a visible guard status `SELECT` that returns `OK_TO_RUN` or `STOP_BACKUP_TABLE_ALREADY_EXISTS` as `ryderwear_contour_pilot_guard_status`. 
- Make backup snapshot creation conditional on the guard (create backup only when `@ryderwear_contour_backup_exists = 0`). 
- Block the controlled `INSERT` by adding `AND @ryderwear_contour_backup_exists = 0` to the `WHERE` clause, and preserve the existing `CASE` categoryId mapping (`Tops->1`, `Pants->2`, `Set->4`, `Equipment->8`, `ELSE 0`) while not reintroducing any `JOIN category`. 

### Testing
- Ran repository pattern checks (`rg`) to confirm `@ryderwear_contour_backup_exists`, `OK_TO_RUN`, `STOP_BACKUP_TABLE_ALREADY_EXISTS`, and `AND @ryderwear_contour_backup_exists = 0` are present in the modified file, and that no `JOIN category` was reintroduced; these checks succeeded. 
- Inspected the file diff to confirm only `docs/operations/generated/sql/ryderwear-contour-inactive-pilot-insert.sql` was modified and the `CASE` mapping and pilot invariants remain intact; inspection succeeded. 
- Confirmed no SQL was executed as part of these changes. All automated checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a125890531883249772914977025543)