### PR TITLE
Fix rollback staging reset in remaining-pending-products-inactive-insert.sql

### DIFF
--- a/docs/operations/generated/sql/remaining-pending-products-inactive-insert.sql
+++ b/docs/operations/generated/sql/remaining-pending-products-inactive-insert.sql
@@ -404,10 +404,9 @@ GROUP BY pis.brand;
 -- -- TRUNCATE TABLE item;
 -- -- INSERT INTO item SELECT * FROM item_backup_before_remaining_pending_inactive_insert;
 
--- -- ROLLBACK STEP 3: Clear staging db_itemId values only for this inserted range if needed.
--- UPDATE product_import_staging pis
--- JOIN item_backup_before_remaining_pending_inactive_insert b
---     ON b.external_item_id = pis.model_id
--- SET pis.db_itemId = NULL
--- WHERE pis.db_itemId BETWEEN 59 AND 120
---   AND pis.brand IN ('Adidas', 'Ryderwear');
+-- -- ROLLBACK STEP 3: Only run if rolling back this inserted inactive batch (db_itemId 59-120).
+-- UPDATE product_import_staging
+-- SET db_itemId = NULL
+-- WHERE db_itemId BETWEEN 59 AND 120
+--   AND brand IN ('Adidas', 'Ryderwear')
+--   AND (images IS NULL OR TRIM(images) = '');


### PR DESCRIPTION
### Motivation
- The existing commented rollback `UPDATE` joined `product_import_staging` to `item_backup_before_remaining_pending_inactive_insert`, which would likely affect zero rows because the backup is created before the new rows are inserted, so a safer manual rollback approach is needed.

### Description
- Replaced the commented JOIN-based staging rollback in `docs/operations/generated/sql/remaining-pending-products-inactive-insert.sql` with a commented direct guarded statement `UPDATE product_import_staging SET db_itemId = NULL WHERE db_itemId BETWEEN 59 AND 120 AND brand IN ('Adidas', 'Ryderwear') AND (images IS NULL OR TRIM(images) = '');`, left the rollback manual/commented, and limited this change to only `docs/operations/generated/sql/remaining-pending-products-inactive-insert.sql` while keeping the `INSERT` logic and `db_itemId` assignment (59–120), `is_active = 0`, `featured = 0`, `assignment_source = 'custom'`, and `external_item_id = model_id` unchanged.

### Testing
- No automated tests were run; verification was performed by inspecting the modified file to confirm the rollback remains commented, the JOIN to `item_backup_before_remaining_pending_inactive_insert` was removed from the rollback `UPDATE`, and no other files or insert logic were changed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a12613c7794832490b810a12fdeba49)