### PR TITLE
Add 11 May README planning timeline summary

### DIFF
--- a/docs/operations/generated/2026-05-11-readme-planning-timeline-summary.md
+++ b/docs/operations/generated/2026-05-11-readme-planning-timeline-summary.md
@@ -1,0 +1,50 @@
+# 2026-05-11 README Planning Timeline Summary
+
+## Purpose
+
+This generated summary consolidates the planning/audit README documents filed under `README/V-AUDIT/POST-AUDIT/` with filenames starting `2026-05-11-`, to provide evidence that the Sports Warehouse Hero Manager work began with architecture, governance, diagnostics, and workflow-definition documentation before visible admin-backend design iteration.
+
+## Files reviewed
+
+| File | Stage/topic | Purpose | What we were doing | Why it mattered later | Phase type |
+|---|---|---|---|---|---|
+| `2026-05-11-Stage-2D-Hero-Candidate-Diagnostic-Format.md` | Stage 2D diagnostic format baseline | Establishes accepted Stage 2D diagnostic JSON schema and boundaries. | Defining diagnostic vocabulary, evidence fields, and non-goals (no authority/UI/database behavior). | Created the shared diagnostic language later consumed by adapter/endpoint shortlist work. | Diagnostics / planning |
+| `2026-05-11-Stage-3A-Hero-Diagnostics-Integration-Planning.md` | Stage 3A integration planning | Plans how Hero Manager could safely consume diagnostics in future. | Setting governance rule (manual authority wins), planning adapter-layer direction, and field-safety groupings. | Prevented unsafe direct JSON wiring and set integration guardrails for admin/backend stages. | Planning / governance |
+| `2026-05-11-Stage-3B-Hero-Diagnostics-Adapter-Contract.md` | Stage 3B adapter contract | Defines the proposed read-only adapter contract. | Specifying supported schema handling, statuses, source path assumptions, and forbidden write behaviors. | Gave a concrete contract for safe backend diagnostics exposure without changing hero authority. | Implementation preparation / governance |
+| `2026-05-11-Stage-3C-Hero-Manager-Candidate-Data-Flow-Audit.md` | Stage 3C data-flow audit | Audits current Hero Manager candidate flow and best attachment point. | Inspecting existing admin/PHP/JS flow and identifying `admin/hero-candidates.php` as safest surface. | Reduced integration risk and anchored later endpoint enrichment strategy. | Diagnostics / implementation preparation |
+| `2026-05-11-Stage-3D-Hero-Diagnostics-Adapter-Implementation-Plan.md` | Stage 3D adapter implementation planning | Converts earlier audit/contract work into a stepwise implementation boundary plan. | Defining allowed vs forbidden future adapter actions and explicit no-change scope. | Ensured later implementation stayed read-only and did not impact ranking/overrides/authority. | Implementation preparation / governance |
+| `2026-05-11-Stage-3F-Hero-Diagnostics-Adapter-Code-Review.md` | Stage 3F adapter safety review | Reviews adapter read-only safety before broader integration. | Verifying no DB writes, no ranking/authority changes, safe include behavior, and schema validation behavior. | Produced evidence that backend diagnostic plumbing could be introduced safely. | Diagnostics / governance |
+| `2026-05-11-Stage-3G-Hero-Candidates-Diagnostics-Integration-Plan.md` | Stage 3G endpoint enrichment plan | Plans minimal integration of diagnostics into candidate endpoint output. | Designing additive `diagnostics` field strategy without altering existing scoring/ranking/UI behavior. | Enabled gradual backend evolution while preserving current admin UI expectations. | Implementation preparation |
+| `2026-05-11-Stage-3I-Hero-Candidates-Enriched-Endpoint-Review.md` | Stage 3I enriched endpoint review | Reviews enriched endpoint output before UI badge rendering. | Auditing endpoint behavior and confirming additive, non-invasive diagnostics output. | Validated backend contract stability needed before visible interface changes. | Diagnostics / design preparation |
+| `2026-05-11-Stage-3J-AI-Led-Top-Three-Hero-Candidate-Workflow.md` | Stage 3J workflow direction reset | Reframes Hero Manager toward AI-led top-three shortlist workflow. | Documenting intended normal/challenge editorial flow and authority model. | Set product/UX rationale for later top-three design and admin interaction patterns. | Design preparation / governance |
+| `2026-05-11-Stage-3K-Top-Three-Shortlist-Data-Readiness-Audit.md` | Stage 3K readiness audit | Audits whether current endpoint + diagnostics can support top-three shortlist. | Checking response shape, diagnostics additivity, and no-impact boundaries. | Confirmed technical readiness before formal shortlist contracts and UI plans. | Diagnostics / implementation preparation |
+| `2026-05-11-Stage-3L-Hero-Selection-Criteria-Profiles.md` | Stage 3L criteria-profile definitions | Defines future criteria profiles for context-aware hero recommendations. | Documenting profile concepts and how profiles fit AI recommendation vs editor authority. | Provided policy/rationale layer needed for future criteria-aware shortlist behavior. | Planning / governance / design preparation |
+| `2026-05-11-Stage-3M-Shortlist-Endpoint-Contract.md` | Stage 3M shortlist contract | Designs future endpoint contract for normal scan + challenge workflows. | Specifying response structure (`recommended_candidates`, `all_candidates`, profile metadata, status fields). | Became blueprint for admin/backend shortlist data model used by later UI design. | Implementation preparation |
+| `2026-05-11-Stage-3O-Shortlist-Endpoint-Output-Review.md` | Stage 3O shortlist output review | Reviews opt-in shortlist endpoint output and backward compatibility. | Verifying default endpoint remains stable while shortlist metadata is opt-in. | Protected existing admin tools while enabling iterative rollout of shortlist architecture. | Diagnostics / governance |
+| `2026-05-11-Stage-3P-Product-List-Top-Three-UI-Plan.md` | Stage 3P product-list UI planning | Plans top-three display patterns in product/filtered list view. | Defining scan-first UI behavior, challenge entry wording, and transparency around placeholder basis. | Translated backend shortlist work into practical admin design direction. | Design preparation |
+| `2026-05-11-Stage-3Q-Batch-Shortlist-Endpoint-Plan.md` | Stage 3Q batch endpoint planning | Plans future batch shortlist endpoint for multi-product views. | Scoping performance-oriented batch contract and relationship to single-item endpoint. | Prepared for scalable admin list workflows beyond single-item inspection. | Implementation preparation |
+| `2026-05-11-Stage-3R-Shared-Hero-Shortlist-Helper-Contract.md` | Stage 3R shared helper contract | Designs shared shortlist helper to avoid duplicated endpoint logic. | Defining helper responsibilities, read-only boundaries, and non-goals. | Improved maintainability and consistency for single-item + future batch shortlist endpoints. | Implementation preparation / governance |
+| `2026-05-11-Stage-3T-Shared-Shortlist-Helper-Review.md` | Stage 3T shared helper review | Reviews helper safety, boundary ownership, and delegation from endpoint. | Confirming helper remains read-only and endpoint delegation preserves behavior. | Strengthened technical foundation for later shortlist/admin workflow expansion. | Diagnostics / implementation preparation |
+
+## 11 May planning-day summary
+
+The `2026-05-11-*` README set documents a planning-first and architecture-first phase: schema definition, governance rules, data-flow audits, adapter/endpoint contracts, safety reviews, and shortlist workflow planning were written before visible interface iteration. The recurring constraints were explicit: read-only diagnostics integration, no authority takeover, no scoring/ranking side effects, and manual Hero Manager decisions remaining final.
+
+Note: several files in this `2026-05-11-*` filename set record internal stage dates of **2026-05-12** while still belonging to the same documented planning sequence.
+
+## How this connects to the later admin backend design work
+
+Based on this planning corpus, the timeline can be stated factually as:
+
+- **11 May 2026:** planning and architecture-documentation day (diagnostic format, contracts, safety boundaries, integration and shortlist direction).
+- **12 May 2026:** no screenshot-led visible design work evidenced in this summary set; activity appears to remain documentation/review-oriented.
+- **13 May 2026:** visible admin-backend design work begins (outside this specific file set).
+- **14–18 May 2026:** Hero Manager design/rationale workflow, candidate-image review approach, and admin interface direction are developed (as later stages progress).
+- **18–26 May 2026:** work shifts further into technical ProductDB/image-folder/GitHub/MySQL operational workflow.
+- **26 May 2026 (morning):** Ryderwear image-ready admin backend milestone completion point.
+
+The key evidence contribution from this generated summary is that early workflow effort was not absent—it was front-loaded into structured planning, governance, and integration documentation before screenshot-visible UI progression.
+
+## Meeting-use summary
+
+On 11 May, the Sports Warehouse Hero Manager work was already active, but in a planning-and-architecture phase rather than a screenshot-visible UI phase. The README planning sequence shows we first defined diagnostic schema boundaries, governance rules, read-only integration contracts, shortlist workflow direction, and safety checks so later backend/admin design could proceed without breaking manual editorial authority. In practical terms: 11 May established the technical and governance foundation; visible admin design began later (from 13 May onward), then evolved through Hero Manager shortlist/interface development and into the deeper ProductDB/image/GitHub/MySQL execution phase through 26 May.


### PR DESCRIPTION
### Motivation

- Prepare concise, evidence-based material for a TAFE meeting showing the Sports Warehouse work began with planning/architecture documentation on 11 May rather than visible admin-backend screenshots. 
- Consolidate the `README/V-AUDIT/POST-AUDIT/2026-05-11-*` planning documents into a single easy-to-read summary for meeting and audit use.

### Description

- Adds one generated Markdown summary at `docs/operations/generated/2026-05-11-readme-planning-timeline-summary.md` that contains a per-file table, an 11 May planning-day narrative, a connection to later admin/backend work, and a short "Meeting-use summary" paragraph. 
- The table summarizes each `2026-05-11-*` README with filename, stage/topic, one-sentence purpose, what work was done, why it mattered for later Hero Manager/admin work, and the phase type. 
- No original README files, source code, database files, images, CSVs, or admin/frontend PHP were modified. 
- Only the single generated file above was created.

### Testing

- Confirmed the generated file exists with `test -f docs/operations/generated/2026-05-11-readme-planning-timeline-summary.md` which returned `exists: yes`.
- Captured `git status --short` output prior to adding the file which showed the single untracked generated file:

```
?? docs/operations/generated/2026-05-11-readme-planning-timeline-summary.md
```

- Captured `git status --short` output after adding the file (clean working tree), which produced no further output (empty result), indicating no other changes were present.
- All automated checks performed (file existence and repository status) succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a150041b01c8324b15efac2a1d8b8b9)