### PR TITLE
Add Sports Warehouse May README timeline summary

### DIFF
--- a/docs/operations/generated/2026-05-sports-warehouse-readme-timeline-summary.md
+++ b/docs/operations/generated/2026-05-sports-warehouse-readme-timeline-summary.md
@@ -1,0 +1,39 @@
+# Sports Warehouse README Timeline Summary — May 2026
+
+## Purpose
+This generated summary consolidates README-based evidence from **11 May 2026 to 26 May 2026** to support a TAFE meeting narrative. It tracks how documented planning and governance moved into visible admin-backend/Hero Manager design work, then into CSV/ProductDB/image-folder/GitHub/MySQL execution planning that underpinned the Ryderwear image-ready backend milestone.
+
+## Timeline by date
+
+| Date | Documents reviewed | Main theme | What we were doing | Later relevance | Phase type |
+|---|---:|---|---|---|---|
+| 2026-05-11 | 17 Stage 2D/3A–3T post-audit docs (hero diagnostics, shortlist logic, endpoint/UI contracts, reviews, and audits) | Architecture and interface planning for hero-candidate intelligence | Defined diagnostic format, adapter contracts, shortlist endpoint behavior, shared helper contracts, product-list UI intent, and review checkpoints | Established the architecture and data contracts later used in Hero Manager/admin workflow decisions | Planning + governance + design preparation |
+| 2026-05-12 | No separate 2026-05-12 filename set in POST-AUDIT; some 2026-05-11 files internally carry Date: 2026-05-12 | Continuity/document finalization day rather than a new visible milestone day | Evidence suggests continuation/refinement of 11 May planning set; no large separate README batch stamped 12 May | Supports the interpretation that core scaffolding was already documented before visible backend iteration accelerated | Governance / documentation continuity |
+| 2026-05-13 | 2 docs (Stage 3V verification; Stage 3W Hero Manager UI integration plan) | First explicit local verification + admin-backend product-list integration planning | Verified shortlist endpoint locally and planned product-list integration path into Hero Manager | Marks the transition to visible Codex/admin-backend design iteration | Design iteration + verification |
+| 2026-05-14 | 2 docs (Stage 3AB, 3AC) | Human-override rationale workflow and storage design | Designed rationale capture UI/data model and persistence approach for manual/admin overrides | Directly informs admin backend behavior, review traceability, and controllable hero decisions | Design iteration + implementation planning |
+| 2026-05-15 | 3 docs (Stage 3AM, 3AS, 3AT) | Hero Manager acceptance review and rationale model expansion | Reviewed acceptance/readiness, then designed future rationale taxonomy plus snapshot/comparison model | Strengthened operational governance and decision explainability in admin workflows | Governance + design iteration |
+| 2026-05-18 | 1 doc (CSV Source-of-Truth ↔ MySQL alignment plan) | Start of CSV/ProductDB/MySQL alignment stream | Defined alignment path between CSV source-of-truth and MySQL ingestion expectations | Pivot point from hero-design iteration into technical data execution workflow | Implementation planning |
+| 2026-05-20 | 1 doc (MySQL schema migration design, no execution) | Controlled schema migration planning | Designed migration sequence without running live destructive actions | Prepared the technical foundation for safer ProductDB/image and importer workflows | Technical execution planning |
+| 2026-05-21 | 14 docs (governance decisions, remediation policy/design, dry-run importer design, allowlist, duplicate resolution, illustrative SQL) | Full migration-control and import-governance package | Built non-executing importer/remediation design stack: required fields, gating, report format, allowlist, duplicate policy, crop governance, checklist/pseudocode/design consistency | This is the main bridge from planning into executable operational readiness for ProductDB/image-folder/GitHub/MySQL work | Governance + implementation planning + verification preparation |
+| 2026-05-23 | 4 docs (field ownership policy, staging mapping checklist, import runbook, retrospective) | Operational runbook and ownership hardening | Formalized CSV field ownership/remediation policy; defined DBeaver staging mapping and CSV-to-MySQL import runbook; captured framework retrospective | Converts prior design/governance into repeatable operator workflow for image/database ingestion | Technical execution + verification |
+| 2026-05-24 to 2026-05-26 (README evidence window) | No additional dated POST-AUDIT README files located in this subset | Consolidation window | Existing 18–23 May governance/runbook stack appears to carry forward into implementation activity | Supports a cautious claim: documentation groundwork was complete before the 26 May morning milestone claim | Verification / consolidation |
+
+## Key phases
+
+### 11 May — planning and architecture documentation
+11 May was a high-volume planning/documentation/architecture day. The README set captured contracts, data-flow audits, shortlist logic, adapter behavior, review points, and UI/endpoint intent for the Hero Manager track before significant visible admin-interface iteration.
+
+### 13–18 May — admin backend and Hero Manager design iteration
+13 May introduced explicit local verification and product-list integration planning. 14–15 May then deepened the admin design with human-override rationale capture and storage models, plus acceptance and taxonomy/snapshot model design. By 18 May, focus shifted toward CSV/MySQL alignment, linking UI/admin logic to data-ingestion realities.
+
+### 18–26 May — ProductDB, image-folder, GitHub and MySQL workflow
+From 18 May onward, README evidence moves into source-of-truth alignment, migration design, remediation controls, dry-run importer design, field governance, mapping checklists, and runbooks. This trajectory reflects the ProductDB/image-folder/GitHub/MySQL operating workflow needed for safe ingestion and admin readiness.
+
+### 26 May morning — Ryderwear image-ready admin backend milestone
+Within this README evidence set, there is no newly dated POST-AUDIT file on 26 May itself; however, the 18–23 May documentation shows a completed chain from planning to governed execution design. That makes the 26 May morning Ryderwear image-ready admin backend milestone consistent with the documented progression, while avoiding unsupported claims about undocumented steps.
+
+## Evidence value
+These README records matter because they show a **traceable development method**: contracts first, governance checks, interface/data design, then controlled execution planning and operator runbooks. This supports the meeting position that visible AI-assisted admin design and later technical execution were grounded in documented policy, review, and staged readiness—not random one-off AI outputs.
+
+## Meeting-use timeline
+From 11 May to 26 May, the documentation shows a clear sequence: we first established Hero Manager architecture and governance contracts, then moved into visible admin-backend and rationale-design iteration from 13–18 May, and then shifted into the ProductDB/image-folder/GitHub/MySQL stream with migration, remediation, dry-run importer, and runbook controls from 18–23 May. By the morning of 26 May, that documented groundwork had matured into the Ryderwear image-ready admin backend milestone.


### PR DESCRIPTION
### Motivation
- Provide concise, date-grouped README evidence for a TAFE meeting that traces Sports Warehouse work from planning and governance into admin-backend/Hero Manager design and then into ProductDB/image-folder/GitHub/MySQL execution readiness.

### Description
- Adds a single generated Markdown timeline at `docs/operations/generated/2026-05-sports-warehouse-readme-timeline-summary.md` that consolidates README evidence dated 2026-05-11 through 2026-05-26. 
- The summary groups README items by date and for each date lists documents reviewed, the main theme, what work was being done, later relevance to the admin/Hero Manager/ProductDB workflows, and a phase type. 
- Includes key-phase narrative sections for the 11 May planning day, 13–18 May admin/Hero Manager design iteration, 18–26 May ProductDB/image-folder/GitHub/MySQL workflow, and a cautious note about the 26 May milestone consistency with prior documentation. 

### Testing
- Confirmed the generated file exists at `docs/operations/generated/2026-05-sports-warehouse-readme-timeline-summary.md` and printed its contents for verification. 
- `git status --short` prior to recording the change showed: `?? docs/operations/generated/2026-05-sports-warehouse-readme-timeline-summary.md`. 
- After the change was recorded, `git status --short` returned an empty/clean working tree, indicating the working tree contained no uncommitted changes. 
- No other README, code, CSV, DB, image, frontend, admin, or script files were modified as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15036bf2f4832491cb3f56578391ba)