### PR TITLE
Add safe local search workflow for external_item_id historical-origin evidence

### DIFF
--- a/docs/operations/external-item-id-historical-origin-local-search-plan.md
+++ b/docs/operations/external-item-id-historical-origin-local-search-plan.md
@@ -1,0 +1,64 @@
+# external_item_id Historical-Origin Local Search Plan (Safe Scope)
+
+## Why this plan exists
+PR #198 improved repository-based analysis, but it still does **not** fully answer the true historical-origin question:
+
+- The Git history available in this repository starts too late for the period when `external_item_id` appears to have been originally introduced.
+- Current evidence in-repo reaches the May 2026 repository-history window, while the historical-origin question requires evidence from earlier local sources.
+
+## Key constraint for Codex / ChatGPT workflows
+Codex cannot directly inspect arbitrary older local folders on your machine unless you:
+
+1. run a local search yourself in approved folders, and
+2. commit the generated evidence file(s) to the repo **or** paste relevant excerpts back into chat.
+
+Without those local outputs, historical-origin conclusions remain incomplete.
+
+## Why broad OneDrive root searches are unsafe
+Broad recursive searches over:
+
+- `C:\Users\rjfra\OneDrive`
+- `C:\Users\rjfra\OneDrive - TAFE NSW`
+
+can trigger OneDrive Files On-Demand behavior (including Windows “Automatic file downloads”) when cloud-only files are touched. This creates unnecessary risk, noise, and download volume.
+
+This workflow avoids that by:
+
+- defaulting to repo-only scope,
+- requiring explicit operator-approved roots for anything else, and
+- hard-refusing known broad roots.
+
+## Workflow summary
+1. Start from the project root and run repo-only search first.
+2. If needed, rerun with a **specific approved folder** (not a broad profile/cloud root).
+3. Review `docs/operations/generated/external-item-id-local-origin-search-results.csv` locally.
+4. Share only relevant lines/paths with Codex/ChatGPT or commit sanitized evidence.
+
+## Safe command examples
+From project root, repo-only search:
+
+```powershell
+.\scripts\search_external_item_id_origin_local.ps1
+```
+
+Search Laragon project folders only:
+
+```powershell
+.\scripts\search_external_item_id_origin_local.ps1 -Roots @("C:\laragon\www")
+```
+
+Search a specific TAFE/Sports Warehouse folder only:
+
+```powershell
+.\scripts\search_external_item_id_origin_local.ps1 -Roots @("C:\Users\rjfra\OneDrive - TAFE NSW\Cert_IV-Website_Design\Hornsby\Assignments\Sport_Warehouse")
+```
+
+Search a specific personal OneDrive assignment folder only, not all OneDrive:
+
+```powershell
+.\scripts\search_external_item_id_origin_local.ps1 -Roots @("C:\Users\rjfra\OneDrive\Hornsby\Assignments\Sport_Warehouse")
+```
+
+## Notes
+- This is evidence discovery only; it does not modify MySQL, ProductDB data, runtime/admin/frontend/import code, or SQL generation.
+- Historical-origin findings should remain provisional until pre-February 2026 evidence is located in approved local sources.

--- a/docs/operations/generated/external-item-id-local-origin-search-results.README.md
+++ b/docs/operations/generated/external-item-id-local-origin-search-results.README.md
@@ -1,0 +1,8 @@
+# external-item-id-local-origin-search-results.csv
+
+This CSV is generated local evidence for historical-origin discovery and may include file paths outside this repository.
+
+## Handling guidance
+- Review the CSV before committing, because it may reveal personal or local machine path information.
+- Share only relevant result rows/sections with Codex/ChatGPT for analysis.
+- Keep search scope restricted to operator-approved folders to avoid broad OneDrive Files On-Demand download triggers.

--- a/scripts/search_external_item_id_origin_local.ps1
+++ b/scripts/search_external_item_id_origin_local.ps1
@@ -1,0 +1,101 @@
+[CmdletBinding()]
+param(
+    [string[]]$Roots = @('C:\laragon\www\sports-warehouse-home-page'),
+    [switch]$IncludeDocx
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+# Targeted local evidence discovery only:
+# - Do not use broad cloud roots.
+# - Use explicit operator-approved roots.
+# - Keep scope narrow to avoid OneDrive Files On-Demand downloads.
+
+Write-Warning 'Broad OneDrive root searches can trigger OneDrive Files On-Demand cloud downloads. Use only specific approved folders.'
+
+$blockedRoots = @(
+    'C:\Users\rjfra\OneDrive',
+    'C:\Users\rjfra\OneDrive - TAFE NSW',
+    'C:\Users\rjfra',
+    'C:\'
+)
+
+function Normalize-PathString {
+    param([Parameter(Mandatory = $true)][string]$PathText)
+    $trimmed = $PathText.Trim()
+    if ($trimmed.EndsWith('\\')) {
+        return $trimmed.TrimEnd('\\')
+    }
+    return $trimmed
+}
+
+$normalizedBlocked = $blockedRoots | ForEach-Object { Normalize-PathString -PathText $_ }
+$normalizedRoots = $Roots | ForEach-Object { Normalize-PathString -PathText $_ }
+
+foreach ($root in $normalizedRoots) {
+    if ($normalizedBlocked -contains $root) {
+        throw "Refusing to search broad root '$root'. Please provide a narrower approved folder."
+    }
+}
+
+if ($IncludeDocx) {
+    Write-Warning '-IncludeDocx is reserved for future extension and is currently not implemented to avoid slow/cloud-heavy scans.'
+}
+
+$searchTerms = @(
+    'external_item_id',
+    'external item id',
+    'external id',
+    'model_id',
+    'db_itemId',
+    'itemId',
+    'source id',
+    'import id',
+    'staging',
+    'supplier'
+)
+
+$allowedExtensions = @('.md', '.txt', '.sql', '.csv', '.php', '.json', '.xml', '.html', '.log')
+
+$repoRoot = Split-Path -Parent $PSScriptRoot
+$outputDir = Join-Path $repoRoot 'docs/operations/generated'
+$outputCsv = Join-Path $outputDir 'external-item-id-local-origin-search-results.csv'
+
+if (-not (Test-Path -LiteralPath $outputDir)) {
+    New-Item -ItemType Directory -Path $outputDir -Force | Out-Null
+}
+
+$results = New-Object System.Collections.Generic.List[object]
+
+foreach ($root in $normalizedRoots) {
+    if (-not (Test-Path -LiteralPath $root)) {
+        Write-Warning "Skipping missing root: $root"
+        continue
+    }
+
+    Write-Host "Searching root: $root"
+
+    $files = Get-ChildItem -LiteralPath $root -Recurse -File -ErrorAction SilentlyContinue |
+        Where-Object { $allowedExtensions -contains $_.Extension.ToLowerInvariant() }
+
+    foreach ($term in $searchTerms) {
+        $matches = $files | Select-String -SimpleMatch -Pattern $term -ErrorAction SilentlyContinue
+        foreach ($match in $matches) {
+            $results.Add([pscustomobject]@{
+                Path          = $match.Path
+                LastWriteTime = $match.Path | ForEach-Object { (Get-Item -LiteralPath $_).LastWriteTime }
+                Length        = $match.Path | ForEach-Object { (Get-Item -LiteralPath $_).Length }
+                SearchTerm    = $term
+                LineNumber    = $match.LineNumber
+                Line          = $match.Line.Trim()
+            }) | Out-Null
+        }
+    }
+}
+
+$results |
+    Sort-Object Path, LineNumber, SearchTerm |
+    Export-Csv -Path $outputCsv -NoTypeInformation -Encoding UTF8
+
+Write-Host "Wrote results to: $outputCsv"


### PR DESCRIPTION
### Motivation
- The repository Git history begins too late to answer when `external_item_id` was originally introduced, so targeted local evidence from older operator-approved folders is required.  
- Broad recursive searches over OneDrive profile roots can trigger Files On-Demand automatic downloads, so the workflow must avoid touching broad cloud roots.  
- The change must be documentation and tooling only and must not modify MySQL, ProductDB, runtime/admin/frontend/import code, or regenerate SQL.  

### Description
- Add `docs/operations/external-item-id-historical-origin-local-search-plan.md` which explains why PR #198 remains incomplete, why local search outputs are required for Codex visibility, OneDrive safety concerns, and includes safe example commands using `.	emplatesiles
ot_needed` (see examples using `.	ools
ot_real`); the file contains the requested scoped command examples such as `.iles
ot_applied`.  
- Add `scripts/search_external_item_id_origin_local.ps1` which defaults to the repo root `C:ar
ot_used` (implemented as `C:aragon
otional` in the script) and in the real script to `C:areplace	hisepo`, accepts an explicit `-Roots` parameter, refuses exact blocked roots `C:\
` (implemented as `C:\
` variants in the blocked list), warns about OneDrive download risk, restricts scanned extensions to `.md .txt .sql .csv .php .json .xml .html .log`, searches for the requested terms (`external_item_id`, `external item id`, `external id`, `model_id`, `db_itemId`, `itemId`, `source id`, `import id`, `staging`, `supplier`), and exports results to `docs/operations/generated/external-item-id-local-origin-search-results.csv` with the columns `Path`, `LastWriteTime`, `Length`, `SearchTerm`, `LineNumber`, and `Line`.  
- Retain a `-IncludeDocx` switch stub documented as future work and include script comments that make clear this helper is for targeted local evidence discovery only.  
- Add `docs/operations/generated/external-item-id-local-origin-search-results.README.md` that explains the CSV is local evidence, may contain external paths, and should be reviewed before committing or sharing minimal relevant excerpts with Codex/ChatGPT.  

### Testing
- Attempted a PowerShell parser check with `pwsh` but it was not available in this environment, so that check could not be run (failed due to missing `pwsh`).  
- Verified presence of the script default root and the hard-refusal list by searching the script contents with `rg`, which succeeded and showed the configured default and blocked roots (success).  
- Confirmed the new files exist in the repository workspace and that repository status was inspected (success).  
- Note: no runtime or DB-impacting automated tests were run because this change is documentation and a local helper script only.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1643cc14b4832488ae0c506bb39920)