### PR TITLE
Align Hero Manager shortlist endpoint with status filter

### DIFF
--- a/admin/hero-manager.php
+++ b/admin/hero-manager.php
@@ -725,6 +725,7 @@ admin_layout_start("Hero Manager");
 
 <script>
   window.BASE_URL = "<?= BASE_URL ?>";
+  window.HERO_STATUS_FILTER = <?= json_encode($statusFilter, JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT) ?>;
 </script>
 <script src="<?= BASE_URL ?>/js/admin/hero.js"></script>
 

--- a/admin/hero-shortlists.php
+++ b/admin/hero-shortlists.php
@@ -13,8 +13,18 @@ $offset = max(0, $offset);
 $brand = trim((string)($_GET['brand'] ?? ''));
 $section = trim((string)($_GET['section'] ?? ''));
 $q = trim((string)($_GET['q'] ?? ''));
+$status = strtolower(trim((string)($_GET['status'] ?? 'active')));
+$allowedStatuses = ['active', 'inactive', 'all'];
+if (!in_array($status, $allowedStatuses, true)) {
+    $status = 'active';
+}
 
-$where = ["i.is_active = 1"];
+$where = [];
+if ($status === 'active') {
+    $where[] = 'i.is_active = 1';
+} elseif ($status === 'inactive') {
+    $where[] = 'i.is_active = 0';
+}
 $params = [];
 
 if ($brand !== '') {
@@ -33,7 +43,7 @@ if ($q !== '') {
     $params[':q'] = '%' . $q . '%';
 }
 
-$whereSql = 'WHERE ' . implode(' AND ', $where);
+$whereSql = $where ? ('WHERE ' . implode(' AND ', $where)) : '';
 
 $sql = "
     SELECT
@@ -122,6 +132,7 @@ echo json_encode([
         'category' => null,
         'limit' => $limit,
         'offset' => $offset,
+        'status' => $status,
     ],
     'products' => $products,
     'summary' => [

--- a/js/admin/hero.js
+++ b/js/admin/hero.js
@@ -442,7 +442,13 @@ document.addEventListener("DOMContentLoaded", () => {
       node.appendChild(makeEl("div", "hero-shortlist-preview__state", message));
     };
 
-    fetch(`${String(window.BASE_URL || "").replace(/\/+$/, "")}/admin/hero-shortlists.php?limit=100`)
+    const statusFilterRaw = String(window.HERO_STATUS_FILTER || "active").toLowerCase().trim();
+    const statusFilter = ["active", "inactive", "all"].includes(statusFilterRaw) ? statusFilterRaw : "active";
+    const shortlistUrl = new URL(`${String(window.BASE_URL || "").replace(/\/+$/, "")}/admin/hero-shortlists.php`, window.location.origin);
+    shortlistUrl.searchParams.set("limit", "100");
+    shortlistUrl.searchParams.set("status", statusFilter);
+
+    fetch(shortlistUrl.toString())
       .then(res => {
         if (!res.ok) {
           throw new Error("endpoint");


### PR DESCRIPTION
### Motivation
- The hero shortlist preview showed “Shortlist unavailable” for inactive items because the page-level status scope was not propagated to the `hero-shortlists.php` endpoint and the endpoint was hard-coded to `i.is_active = 1`.
- The intent is to make shortlist previews respect the same `status` scope (`active|inactive|all`) used by `admin/hero-manager.php` without changing any product data or public/catalog behavior.

### Description
- Expose the current admin status filter to client code by rendering `window.HERO_STATUS_FILTER` in `admin/hero-manager.php` (JSON-escaped). 
- Update `js/admin/hero.js` to read and allowlist `window.HERO_STATUS_FILTER` and include it as a `status` query parameter when fetching `/admin/hero-shortlists.php` using `URL`/`searchParams`.
- Modify `admin/hero-shortlists.php` to accept an allowlisted `status` param (default `active`) and apply the same SQL scope semantics (`active` => `i.is_active = 1`, `inactive` => `i.is_active = 0`, `all` => no `is_active` predicate) while preserving `brand`, `section`, and `q` filters.
- Emit the chosen `status` in the endpoint JSON `active_scope` payload and otherwise preserve existing shortlist contract logic.

### Testing
- Ran `php -l admin/hero-manager.php` and `php -l admin/hero-shortlists.php` and both returned "No syntax errors detected". 
- Performed automated code checks (`rg`) to confirm `window.HERO_STATUS_FILTER` is present and that `js/admin/hero.js` now passes a `status` param and `admin/hero-shortlists.php` parses/returns `status` in `active_scope`. 
- Verified by inspection that the Hero Manager still defaults to `active` and that the shortlist endpoint now receives and honors `status=active|inactive|all` without any MySQL/ProductDB mutations.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a16c2669c548324802e367fe1dd63bc)