### PR TITLE
Add Inactive Product Review admin menu entry

### DIFF
--- a/admin/_nav.php
+++ b/admin/_nav.php
@@ -7,6 +7,8 @@
 function admin_render_nav(): string
 {
     $path = parse_url($_SERVER['REQUEST_URI'] ?? '', PHP_URL_PATH) ?: '';
+    $query = parse_url($_SERVER['REQUEST_URI'] ?? '', PHP_URL_QUERY) ?: '';
+    parse_str($query, $currentQueryParams);
 
     if (preg_match('#^(.*?/admin)(?:/|$)#', $path, $m)) {
         $adminBase = rtrim($m[1], '/');   // e.g. /sports-warehouse-home-page/admin OR /admin
@@ -33,6 +35,13 @@ function admin_render_nav(): string
                 'href'  => $adminBase . '/hero-manager.php',
                 'icon'  => 'fa-solid fa-images',
                 'label' => 'Hero Manager',
+                'excludeQuery' => ['status' => 'inactive'],
+            ],
+            [
+                'href'       => $adminBase . '/hero-manager.php?status=inactive',
+                'icon'       => 'fa-solid fa-eye-slash',
+                'label'      => 'Inactive Product Review',
+                'matchQuery' => ['status' => 'inactive'],
             ],
             [
                 'href'  => $adminBase . '/hero-edit.php',
@@ -104,6 +113,25 @@ function admin_render_nav(): string
             $hrefNorm = $normalize($item['href']);
             $isActive = ($hrefNorm === $currentPath);
 
+            if ($isActive && !empty($item['matchQuery']) && is_array($item['matchQuery'])) {
+                foreach ($item['matchQuery'] as $key => $expectedValue) {
+                    $actualValue = isset($currentQueryParams[$key]) ? (string)$currentQueryParams[$key] : null;
+                    if ((string)$expectedValue !== $actualValue) {
+                        $isActive = false;
+                        break;
+                    }
+                }
+            }
+            if ($isActive && !empty($item['excludeQuery']) && is_array($item['excludeQuery'])) {
+                foreach ($item['excludeQuery'] as $key => $excludedValue) {
+                    $actualValue = isset($currentQueryParams[$key]) ? (string)$currentQueryParams[$key] : null;
+                    if ((string)$excludedValue === $actualValue) {
+                        $isActive = false;
+                        break;
+                    }
+                }
+            }
+
             if (
                 !$isActive &&
                 $hrefNorm === $normalize($adminBase . '/index.php') &&
@@ -131,4 +159,3 @@ function admin_render_nav(): string
     $html .= '</nav>';
     return $html;
 }
-

--- a/admin/hero-manager.php
+++ b/admin/hero-manager.php
@@ -382,6 +382,7 @@ $enforcementSummary = $pdo
    6. LAYOUT START
    ============================================================ */
 admin_layout_start("Hero Manager");
+$isInactiveReviewView = ($statusFilter === 'inactive');
 ?>
 
 <link rel="stylesheet" href="<?= BASE_URL ?>/css/admin/hero.css">
@@ -403,9 +404,14 @@ admin_layout_start("Hero Manager");
          Header
          ======================================================== -->
     <header class="admin-header hero-admin__header">
-        <h1><i class="fa-solid fa-images"></i> Hero Manager</h1>
+        <h1>
+            <i class="fa-solid fa-images"></i>
+            <?= $isInactiveReviewView ? 'Inactive Product Review' : 'Hero Manager' ?>
+        </h1>
         <p class="subtitle">
-            Review all computed hero fields and regenerate them when required.
+            <?= $isInactiveReviewView
+                ? 'These products are not public. This view is for backend image, hero, and readiness preparation only.'
+                : 'Review all computed hero fields and regenerate them when required.' ?>
         </p>
 
         <button type="button" class="btn btn-ghost hero-info-toggle" data-target="heroInfoPanel">
@@ -419,7 +425,9 @@ admin_layout_start("Hero Manager");
         <a class="hero-badge <?= $statusFilter === 'inactive' ? 'hero-badge--manual' : '' ?>" href="hero-manager.php?status=inactive">Inactive only</a>
         <a class="hero-badge <?= $statusFilter === 'all' ? 'hero-badge--manual' : '' ?>" href="hero-manager.php?status=all">All products</a>
         <div class="context-note">
-            Inactive products may be reviewed for hero readiness in admin. Activation/publication remains a separate readiness decision.
+            <?= $isInactiveReviewView
+                ? 'You are reviewing inactive items only. Activation/publication remains a separate readiness decision.'
+                : 'Inactive products may be reviewed for hero readiness in admin. Activation/publication remains a separate readiness decision.' ?>
         </div>
     </div>
 


### PR DESCRIPTION
### Motivation
- Expose the previously hidden `?status=inactive` Hero Manager view as a first-class admin backend feature so admins can review inactive / not-public products from the sidebar. 
- Make the inactive review scope clearer in the page framing while preserving existing Hero Manager behaviour and controls.

### Description
- Added a new sidebar item labeled `Inactive Product Review` linking to `admin/hero-manager.php?status=inactive` in `admin/_nav.php` and preserved the existing `Hero Manager` link to `admin/hero-manager.php`.
- Implemented minimal query-aware active-state handling in `admin_render_nav()` by parsing the request query and supporting `matchQuery` and `excludeQuery` attributes so the new inactive menu entry can be highlighted appropriately and the default Hero Manager item is not simultaneously active.
- Adjusted `admin/hero-manager.php` to detect `status=inactive` and present an explicit `Inactive Product Review` heading, subtitle, and contextual note while leaving the existing `Active only / Inactive only / All products` controls intact.
- Made no changes to database schema, ProductDB logic, image files, hero ranking/candidate logic, public frontend behavior, or activation/readiness filters; this is navigation and page-framing only.

### Testing
- Ran `php -l admin/hero-manager.php` and received no syntax errors.
- Ran `php -l admin/_nav.php` and received no syntax errors.
- Ran `php -l admin/_layout.php` and received no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a16c75f842483249a5dd3b1a7d6cce2)