### PR TITLE
Fix ASCII-sensitive punctuation in Ryderwear Batch 2 approval worksheet

### DIFF
--- a/docs/operations/generated/batches/ryderwear-batch2-2026-05-27-01/next_approval_decision.md
+++ b/docs/operations/generated/batches/ryderwear-batch2-2026-05-27-01/next_approval_decision.md
@@ -1,4 +1,4 @@
-# Ryderwear Batch 2 — Next Approval Decision Worksheet
+# Ryderwear Batch 2 - Next Approval Decision Worksheet
 
 ## Purpose
 This document is a documentation-only approval decision worksheet to unblock controlled source-evidence work for batch `ryderwear-batch2-2026-05-27-01`.
@@ -114,5 +114,5 @@ The following artifacts remain blocked and must **not** be created until approva
 - `suspicious_mapping_report.csv`
 - `copy_simulation.csv`
 
-Exception note: `suspicious_mapping_report.csv` may only be created as a **report-only** artifact after the strategy’s reason-code/evidence/status normalization is explicitly approved and all three suspicious/remap cases have reviewer decisions.
+Exception note: `suspicious_mapping_report.csv` may only be created as a **report-only** artifact after the strategy's reason-code/evidence/status normalization is explicitly approved and all three suspicious/remap cases have reviewer decisions.
 


### PR DESCRIPTION
### Motivation
- Remove encoding-sensitive punctuation from the Ryderwear Batch 2 approval worksheet to avoid mojibake and ensure ASCII-safe rendering in downstream tooling for `ryderwear-batch2-2026-05-27-01`.

### Description
- Replace the em dash in the title with an ASCII hyphen on `docs/operations/generated/batches/ryderwear-batch2-2026-05-27-01/next_approval_decision.md`.
- Replace the curly apostrophe in `strategy’s` with a straight ASCII apostrophe `strategy's` in the exception note.
- No substantive content, decision rows, reviewer fields, artifact references, or blocked-output logic were changed.

### Testing
- Ran `grep -nP '[^\x00-\x7F]' docs/operations/generated/batches/ryderwear-batch2-2026-05-27-01/next_approval_decision.md || true` and observed no non-ASCII characters.
- Ran `grep -nE 'â|Ã|�|—|’|“|”' docs/operations/generated/batches/ryderwear-batch2-2026-05-27-01/next_approval_decision.md || true` and observed no problematic punctuation occurrences.
- Verified only `docs/operations/generated/batches/ryderwear-batch2-2026-05-27-01/next_approval_decision.md` was modified using `git status --short` prior to committing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a17bf37c9d083249b5f2a06631f2d24)