### PR TITLE
Add human reviewer acceptance worksheet for Ryderwear Batch 2

### DIFF
--- a/docs/operations/generated/batches/ryderwear-batch2-2026-05-27-01/human_reviewer_acceptance_worksheet.md
+++ b/docs/operations/generated/batches/ryderwear-batch2-2026-05-27-01/human_reviewer_acceptance_worksheet.md
@@ -1,0 +1,99 @@
+# Human reviewer acceptance worksheet - Ryderwear Batch 2
+
+## Purpose and scope
+This document is a human acceptance worksheet, not an automated approval record.
+
+This worksheet is based on the proposal in `proposed_reviewer_decisions.md` and supporting artifacts listed below. No final approval is recorded in this file.
+
+The human reviewer must evaluate each proposed decision and mark one status:
+- accept_proposed
+- revise_proposed
+- reject_proposed
+- defer_decision
+
+## Source proposal and supporting artifacts reviewed
+Primary source proposal:
+- `proposed_reviewer_decisions.md`
+
+Supporting artifacts:
+- `approval_decision_readiness_review.md`
+- `next_approval_decision.md`
+- `approval_checklist.csv`
+- `destination_collision_report.csv`
+- `publication_gate_report.csv`
+- `image_field_update_plan.csv`
+- `source_evidence_strategy.md`
+
+## 1) Executive summary
+- The source proposal `proposed_reviewer_decisions.md` has been reviewed as the proposal input for this worksheet.
+- Proposed decisions are not final in this worksheet.
+- The human reviewer must accept, revise, reject, or defer each proposed decision before any downstream artifacts can proceed.
+
+## 2) Acceptance table - split-destination decisions dec-001 through dec-011
+
+| decision_id | itemId | proposed_reviewer_decision | confidence level | follow_up_required | human_acceptance_status | human_final_decision | human_reviewer_notes | approval_date |
+|---|---:|---|---|---|---|---|---|---|
+| dec-001 | 138 | approve_split | medium | yes |  |  |  |  |
+| dec-002 | 153 | revise_split_path | medium | yes |  |  |  |  |
+| dec-003 | 154 | revise_split_path | medium | yes |  |  |  |  |
+| dec-004 | 157 | approve_split | high | no |  |  |  |  |
+| dec-005 | 163 | approve_split | high | no |  |  |  |  |
+| dec-006 | 158 | defer_pending_source_verification | low | yes |  |  |  |  |
+| dec-007 | 160 | keep_existing_destination_owner | medium | yes |  |  |  |  |
+| dec-008 | 162 | revise_split_path | medium | yes |  |  |  |  |
+| dec-009 | 174 | revise_split_path | medium | yes |  |  |  |  |
+| dec-010 | 166 | revise_split_path | medium | yes |  |  |  |  |
+| dec-011 | 176 | approve_split | high | yes |  |  |  |  |
+
+## 3) Separate acceptance section - itemId 184 (dec-012)
+
+This decision stays separate from the split table.
+
+Proposed decision (visible for review):
+- decision_id: dec-012
+- itemId: 184
+- proposed_reviewer_decision: defer_pending_source_verification
+- confidence level: high
+- follow_up_required: yes
+
+Source and provenance evidence are required before approval.
+
+| field | value |
+|---|---|
+| human_acceptance_status |  |
+| human_final_decision |  |
+| human_reviewer_notes |  |
+| approved_source_root |  |
+| approval_date |  |
+
+## 4) Acceptance table - suspicious/remap manual-review cases
+
+These decisions require manual review and may require visual evidence and or source evidence before acceptance.
+
+| decision_id | itemId | proposed_reviewer_decision | confidence level | follow_up_required | human_acceptance_status | human_final_decision | human_reviewer_notes | approval_date |
+|---|---|---|---|---|---|---|---|---|
+| suspicious-01 | ryderwear_female_nkd_leggings_v_full_length_scrunch | request_additional_evidence | high | yes |  |  |  |  |
+| suspicious-02 | ryderwear_unisex_gym_bag_accessories | resolved_no_change | high | yes |  |  |  |  |
+| suspicious-03 | ryderwear_female_nkd_shorts_v_scrunch | request_additional_evidence | medium | yes |  |  |  |  |
+
+## 5) Batch-level policy acceptance section
+
+Do not invent an approved_source_root. Record policy outcomes only after human review.
+
+| policy area | proposed_reviewer_decision | human_acceptance_status | human_final_decision | human_reviewer_notes | approval_date |
+|---|---|---|---|---|---|
+| approved source root policy | defer_policy |  |  |  |  |
+| deterministic source_asset_id policy | revise_policy |  |  |  |  |
+| checksum/bytes/mime normalization policy | revise_policy |  |  |  |  |
+| provenance_note policy | approve_policy |  |  |  |  |
+
+## 6) Downstream artifact gate
+
+Downstream artifacts remain blocked until human acceptance is completed and source-root and policy decisions are recorded.
+
+Blocked artifacts:
+- `source_asset_inventory.csv`
+- `suspicious_mapping_report.csv`
+- `copy_simulation.csv`
+
+Do not generate blocked artifacts until this worksheet is completed by the human reviewer.


### PR DESCRIPTION
### Motivation
- Provide a human-facing acceptance worksheet so a reviewer can accept, revise, reject, or defer each proposed decision from `proposed_reviewer_decisions.md` before any downstream artifacts are generated.
- Preserve proposed decisions as proposals and require explicit human-recorded outcomes and provenance/policy choices rather than converting proposals into final decisions.
- Ensure downstream artifact generation remains blocked until source-root/policy decisions and human acceptance are recorded.

### Description
- Add a documentation-only worksheet at `docs/operations/generated/batches/ryderwear-batch2-2026-05-27-01/human_reviewer_acceptance_worksheet.md` containing an executive summary and references to the primary proposal and supporting artifacts.
- Add a split-destination acceptance table for `dec-001` through `dec-011` with the specified columns and blank human-completion fields.
- Add a separate acceptance section for `itemId 184` (dec-012) that keeps the proposed decision visible and requires source/provenance evidence fields, plus a suspicious/remap acceptance table for three manual-review cases.
- Add a batch-level policy acceptance section and an explicit downstream artifact gate that lists `source_asset_inventory.csv`, `suspicious_mapping_report.csv`, and `copy_simulation.csv` as blocked until human acceptance and policy/source-root decisions are recorded.

### Testing
- Confirmed the worksheet references `proposed_reviewer_decisions.md` and all requested supporting artifacts, and this check succeeded.
- Confirmed `source_asset_inventory.csv`, `suspicious_mapping_report.csv`, and `copy_simulation.csv` appear only in the downstream artifact gate as blocked artifacts, and this check succeeded.
- Ran a non-ASCII character scan on the new worksheet and found no non-ASCII characters, and this check succeeded.
- Verified the repository change set contains only the new worksheet file and no existing approval files or downstream artifacts were created, and this check succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a17cc39ab048324bacb2d098b89c05b)