### PR TITLE
Add generic admin Review Approvals entry and current workflow page

### DIFF
--- a/admin/_nav.php
+++ b/admin/_nav.php
@@ -29,6 +29,11 @@ function admin_render_nav(): string
                 'icon'  => 'fa-solid fa-gauge',
                 'label' => 'Dashboard',
             ],
+            [
+                'href'  => $adminBase . '/review-approvals.php',
+                'icon'  => 'fa-solid fa-clipboard-check',
+                'label' => 'Review Approvals',
+            ],
         ],
         'Hero Tools' => [
             [

--- a/admin/review-approvals.php
+++ b/admin/review-approvals.php
@@ -1,0 +1,111 @@
+<?php
+define('ADMIN_CONTEXT', true);
+
+require_once __DIR__ . '/_layout.php';
+require_once __DIR__ . '/_header.php';
+
+$reviewWorkflowStatuses = [
+    'preparing' => 'Preparing',
+    'awaiting_human_acceptance' => 'Awaiting human reviewer acceptance',
+    'accepted' => 'Accepted',
+    'blocked' => 'Blocked',
+    'archived' => 'Archived',
+];
+
+$reviewWorkflows = [
+    [
+        'id' => 'ryderwear-batch-2',
+        'name' => 'Ryderwear Batch 2',
+        'status' => 'awaiting_human_acceptance',
+        'batch_folder' => 'docs/operations/generated/batches/ryderwear-batch2-2026-05-27-01/',
+        'primary_worksheet' => 'human_reviewer_acceptance_worksheet.md',
+        'documents' => [
+            'human_reviewer_acceptance_worksheet.md',
+            'proposed_reviewer_decisions.md',
+            'approval_decision_readiness_review.md',
+            'source_evidence_strategy.md',
+        ],
+        'is_current' => true,
+    ],
+    [
+        'id' => 'future-batch-review',
+        'name' => 'Future batch review',
+        'status' => 'not_configured',
+        'is_current' => false,
+    ],
+    [
+        'id' => 'other-review-workflow',
+        'name' => 'Other review workflow',
+        'status' => 'not_configured',
+        'is_current' => false,
+    ],
+];
+
+$currentWorkflow = null;
+foreach ($reviewWorkflows as $workflow) {
+    if (!empty($workflow['is_current'])) {
+        $currentWorkflow = $workflow;
+        break;
+    }
+}
+
+admin_layout_start('Review Approvals');
+admin_page_header('Review Approvals', 'Track human reviewer acceptance workflows before downstream artifacts are generated.');
+?>
+
+<div class="admin-wrapper">
+    <section class="context-panel">
+        <p><strong>Review approval workflows</strong> are used after preliminary evidence, readiness, and proposed-decision documents have been prepared.</p>
+        <p>A workflow becomes ready for human review when it has a human reviewer acceptance worksheet.</p>
+        <p>Downstream artifacts remain blocked until the reviewer accepts, revises, rejects, or defers the decisions.</p>
+    </section>
+
+    <section class="context-panel">
+        <p><strong>Current review workflow</strong></p>
+        <select aria-label="Current review workflow" disabled>
+            <?php foreach ($reviewWorkflows as $workflow): ?>
+                <?php
+                $isCurrent = !empty($workflow['is_current']);
+                $isConfigured = isset($workflow['status']) && $workflow['status'] !== 'not_configured';
+                $optionLabel = $workflow['name'] . ' - ';
+                $optionLabel .= $isConfigured
+                    ? ($reviewWorkflowStatuses[$workflow['status']] ?? ucfirst(str_replace('_', ' ', $workflow['status'])))
+                    : 'Not configured';
+                ?>
+                <option <?= $isCurrent ? 'selected' : '' ?> <?= $isConfigured ? '' : 'disabled' ?>>
+                    <?= htmlspecialchars($optionLabel) ?>
+                </option>
+            <?php endforeach; ?>
+        </select>
+        <p class="context-note">Workflow selection is explicitly tracked in this page configuration; active workflow is not inferred from folder scan or last-modified time.</p>
+    </section>
+
+    <?php if ($currentWorkflow): ?>
+        <section class="context-panel">
+            <p><strong>Active workflow:</strong> <?= htmlspecialchars($currentWorkflow['name']) ?></p>
+            <p><strong>Status:</strong> <span class="badge badge-accent"><?= htmlspecialchars($reviewWorkflowStatuses[$currentWorkflow['status']] ?? $currentWorkflow['status']) ?></span></p>
+            <p><strong>Batch folder:</strong> <code><?= htmlspecialchars($currentWorkflow['batch_folder']) ?></code></p>
+            <p><strong>Primary worksheet:</strong> <code><?= htmlspecialchars($currentWorkflow['primary_worksheet']) ?></code></p>
+
+            <p><strong>Workflow documents:</strong></p>
+            <ul>
+                <?php foreach ($currentWorkflow['documents'] as $document): ?>
+                    <li><code><?= htmlspecialchars($currentWorkflow['batch_folder'] . $document) ?></code></li>
+                <?php endforeach; ?>
+            </ul>
+            <p class="context-note">Open these paths directly in VS Code if an internal document-linking tool is not available in this environment.</p>
+        </section>
+    <?php endif; ?>
+
+    <section class="context-panel">
+        <p><strong>Guardrail:</strong> The following downstream artifacts remain blocked until human acceptance and policy/source-root decisions are recorded:</p>
+        <ul>
+            <li><code>source_asset_inventory.csv</code></li>
+            <li><code>suspicious_mapping_report.csv</code></li>
+            <li><code>copy_simulation.csv</code></li>
+        </ul>
+    </section>
+</div>
+
+<?php
+admin_layout_end();


### PR DESCRIPTION
### Motivation
- Provide a discoverable, generic admin UI for tracking human review/approval workflows so reviewer acceptance worksheets (like Ryderwear Batch 2) are easy to find and use. 
- Keep the implementation generic and extensible so future review workflows can be added without scanning folders or inferring state from file timestamps.

### Description
- Added a new admin navigation item `Review Approvals` under the `General` group in `admin/_nav.php` that follows existing active-state conventions. 
- Introduced a new admin page `admin/review-approvals.php` that uses the existing admin layout and header and shows explanatory copy about review approval workflows. 
- Implemented a small in-page workflow registry (an explicit array) and status mapping so the active workflow is deterministic and extensible; set `Ryderwear Batch 2` as the current workflow with status `awaiting_human_acceptance`. 
- The page shows the batch folder path, primary worksheet name, and visible document paths for the requested files, and includes the required guardrail listing the downstream artifacts that remain blocked (`source_asset_inventory.csv`, `suspicious_mapping_report.csv`, `copy_simulation.csv`).

### Testing
- Ran `php -l admin/_nav.php` and `php -l admin/review-approvals.php`, both returned no syntax errors. 
- Verified file changes with `git status --short` before committing to ensure only `admin/_nav.php` was modified and `admin/review-approvals.php` was added. 
- Committed the changes with the message `Add admin Review Approvals navigation and workflow page` and confirmed the commit succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a17cf570d6483249bc5c1f61b51539b)