### PR TITLE
Move Review Approvals into WORKFLOW admin nav section

### DIFF
--- a/admin/_nav.php
+++ b/admin/_nav.php
@@ -29,6 +29,8 @@ function admin_render_nav(): string
                 'icon'  => 'fa-solid fa-gauge',
                 'label' => 'Dashboard',
             ],
+        ],
+        'WORKFLOW' => [
             [
                 'href'  => $adminBase . '/review-approvals.php',
                 'icon'  => 'fa-solid fa-clipboard-check',


### PR DESCRIPTION
### Motivation
- Move the `Review Approvals` nav item out of the `General` group into a dedicated `WORKFLOW` sidebar section because it belongs to operational workflow tools rather than general dashboard or diagnostics.

### Description
- Updated `admin/_nav.php` to add a new `WORKFLOW` section and place the existing `Review Approvals` item there while preserving the `href`, `icon`, `label`, and active-state matching logic.

### Testing
- Ran `php -l admin/_nav.php` and `php -l admin/review-approvals.php`, rendered the nav with `php -r` using `$_SERVER['REQUEST_URI']='/admin/review-approvals.php'` to verify the `WORKFLOW` label, link presence, and `is-active` class, and checked `git status --short`; all automated checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a17e219621c83248e940614ee51c306)