### PR TITLE
Improve Review Approvals link usability and relocate Hero Analysis nav item

### DIFF
--- a/admin/_nav.php
+++ b/admin/_nav.php
@@ -60,6 +60,11 @@ function admin_render_nav(): string
                 'icon'  => 'fa-solid fa-chart-simple',
                 'label' => 'Rationale Report',
             ],
+            [
+                'href'  => $adminBase . '/debug/hero-analysis.php',
+                'icon'  => 'fa-solid fa-chart-column',
+                'label' => 'Hero Analysis'
+            ],
         ],
         'Diagnostics' => [
             [
@@ -76,11 +81,6 @@ function admin_render_nav(): string
                 'href'  => $adminBase . '/debug/duplicate-trees.php',
                 'icon'  => 'fa-solid fa-clone',
                 'label' => 'Duplicate Site Trees',
-            ],
-            [
-                'href'  => $adminBase . '/debug/hero-analysis.php',
-                'icon'  => 'fa-solid fa-chart-column',
-                'label' => 'Hero Analysis'
             ],
             [
                 'href'  => $adminBase . '/image-integrity.php',

--- a/admin/review-approvals.php
+++ b/admin/review-approvals.php
@@ -41,6 +41,17 @@ $reviewWorkflows = [
     ],
 ];
 
+$workflowLinks = [];
+foreach ($reviewWorkflows as $workflow) {
+    if (empty($workflow['batch_folder']) || empty($workflow['documents']) || empty($workflow['id'])) {
+        continue;
+    }
+
+    foreach ($workflow['documents'] as $document) {
+        $workflowLinks[$workflow['id']][$document] = 'review-workflow-document.php?workflow=' . rawurlencode($workflow['id']) . '&doc=' . rawurlencode($document);
+    }
+}
+
 $currentWorkflow = null;
 foreach ($reviewWorkflows as $workflow) {
     if (!empty($workflow['is_current'])) {
@@ -83,22 +94,41 @@ admin_page_header('Review Approvals', 'Track human reviewer acceptance workflows
     <?php if ($currentWorkflow): ?>
         <section class="context-panel">
             <p><strong>Active workflow:</strong> <?= htmlspecialchars($currentWorkflow['name']) ?></p>
+            <?php
+            $primaryDoc = $currentWorkflow['primary_worksheet'] ?? '';
+            $primaryDocHref = $workflowLinks[$currentWorkflow['id']][$primaryDoc] ?? null;
+            ?>
             <p><strong>Status:</strong> <span class="badge badge-accent"><?= htmlspecialchars($reviewWorkflowStatuses[$currentWorkflow['status']] ?? $currentWorkflow['status']) ?></span></p>
-            <p><strong>Batch folder:</strong> <code><?= htmlspecialchars($currentWorkflow['batch_folder']) ?></code></p>
-            <p><strong>Primary worksheet:</strong> <code><?= htmlspecialchars($currentWorkflow['primary_worksheet']) ?></code></p>
+            <p><strong>Batch folder:</strong> <code><?= htmlspecialchars($currentWorkflow['batch_folder']) ?></code> <span class="context-note">(Reference path)</span></p>
+            <p><strong>Primary reviewer worksheet:</strong>
+                <?php if ($primaryDocHref): ?>
+                    <a href="<?= htmlspecialchars($primaryDocHref) ?>"><code><?= htmlspecialchars($primaryDoc) ?></code></a>
+                    <span aria-hidden="true">·</span>
+                    <a href="<?= htmlspecialchars($primaryDocHref) ?>">Open acceptance worksheet</a>
+                <?php else: ?>
+                    <code><?= htmlspecialchars($primaryDoc) ?></code>
+                <?php endif; ?>
+            </p>
 
-            <p><strong>Workflow documents:</strong></p>
+            <p><strong>Open workflow documents:</strong></p>
             <ul>
                 <?php foreach ($currentWorkflow['documents'] as $document): ?>
-                    <li><code><?= htmlspecialchars($currentWorkflow['batch_folder'] . $document) ?></code></li>
+                    <?php $docHref = $workflowLinks[$currentWorkflow['id']][$document] ?? null; ?>
+                    <li>
+                        <?php if ($docHref): ?>
+                            <a href="<?= htmlspecialchars($docHref) ?>"><code><?= htmlspecialchars($currentWorkflow['batch_folder'] . $document) ?></code></a>
+                        <?php else: ?>
+                            <code><?= htmlspecialchars($currentWorkflow['batch_folder'] . $document) ?></code>
+                        <?php endif; ?>
+                    </li>
                 <?php endforeach; ?>
             </ul>
-            <p class="context-note">Open these paths directly in VS Code if an internal document-linking tool is not available in this environment.</p>
+            <p class="context-note">Only workflow-registered documents are linked here to avoid unrestricted filesystem browsing.</p>
         </section>
     <?php endif; ?>
 
     <section class="context-panel">
-        <p><strong>Guardrail:</strong> The following downstream artifacts remain blocked until human acceptance and policy/source-root decisions are recorded:</p>
+        <p><strong>Guardrail:</strong> Blocked downstream artifacts remain blocked until human acceptance and policy/source-root decisions are recorded:</p>
         <ul>
             <li><code>source_asset_inventory.csv</code></li>
             <li><code>suspicious_mapping_report.csv</code></li>

--- a/admin/review-workflow-document.php
+++ b/admin/review-workflow-document.php
@@ -1,0 +1,78 @@
+<?php
+define('ADMIN_CONTEXT', true);
+
+require_once __DIR__ . '/_layout.php';
+require_once __DIR__ . '/_header.php';
+
+$reviewWorkflows = [
+    [
+        'id' => 'ryderwear-batch-2',
+        'name' => 'Ryderwear Batch 2',
+        'batch_folder' => 'docs/operations/generated/batches/ryderwear-batch2-2026-05-27-01/',
+        'documents' => [
+            'human_reviewer_acceptance_worksheet.md',
+            'proposed_reviewer_decisions.md',
+            'approval_decision_readiness_review.md',
+            'source_evidence_strategy.md',
+        ],
+    ],
+];
+
+$allowedDocuments = [];
+foreach ($reviewWorkflows as $workflow) {
+    if (empty($workflow['id']) || empty($workflow['batch_folder']) || empty($workflow['documents'])) {
+        continue;
+    }
+    foreach ($workflow['documents'] as $document) {
+        $allowedDocuments[$workflow['id']][$document] = [
+            'workflow_name' => $workflow['name'],
+            'relative_path' => $workflow['batch_folder'] . $document,
+        ];
+    }
+}
+
+$workflowId = (string)($_GET['workflow'] ?? '');
+$documentId = (string)($_GET['doc'] ?? '');
+$docMeta = $allowedDocuments[$workflowId][$documentId] ?? null;
+
+$content = '';
+$error = null;
+$relativePath = '';
+if ($docMeta) {
+    $relativePath = $docMeta['relative_path'];
+    $absolutePath = realpath(__DIR__ . '/../' . $relativePath);
+    $repoRoot = realpath(__DIR__ . '/..');
+
+    if (!$absolutePath || !$repoRoot || strpos($absolutePath, $repoRoot . DIRECTORY_SEPARATOR) !== 0 || !is_file($absolutePath)) {
+        $error = 'Allowed document is currently unavailable on disk.';
+    } else {
+        $read = @file_get_contents($absolutePath);
+        if ($read === false) {
+            $error = 'Unable to read allowed document.';
+        } else {
+            $content = $read;
+        }
+    }
+} else {
+    $error = 'Document is not allowlisted for this workflow.';
+}
+
+admin_layout_start('Review Workflow Document');
+admin_page_header('Review Workflow Document', 'Admin-only allowlisted workflow document viewer.');
+?>
+<div class="admin-wrapper">
+    <section class="context-panel">
+        <p><strong>Workflow:</strong> <?= htmlspecialchars($docMeta['workflow_name'] ?? 'Unknown') ?></p>
+        <p><strong>Reference path:</strong> <code><?= htmlspecialchars($relativePath ?: ($workflowId . '/' . $documentId)) ?></code></p>
+    </section>
+
+    <section class="context-panel">
+        <?php if ($error): ?>
+            <p><strong>Unable to open document:</strong> <?= htmlspecialchars($error) ?></p>
+        <?php else: ?>
+            <pre style="white-space: pre-wrap; overflow-wrap: anywhere; margin: 0;"><?= htmlspecialchars($content) ?></pre>
+        <?php endif; ?>
+    </section>
+</div>
+<?php
+admin_layout_end();


### PR DESCRIPTION
### Motivation
- Make the admin Review Approvals page more actionable and user-friendly by turning clearly actionable workflow artifacts into safe links while keeping non-actionable items visually distinct. 
- Prevent arbitrary filesystem browsing from admin pages by exposing only allowlisted workflow documents through a controlled viewer. 
- Move the existing Hero Analysis nav entry to the correct sidebar group so admin navigation better reflects feature categories.

### Description
- Added an allowlist-based link table in `admin/review-approvals.php` that generates per-workflow links for the primary worksheet and registered workflow documents while keeping the batch folder shown as a non-clickable `Reference path` and clarifying context text. 
- Introduced a new admin-only document viewer at `admin/review-workflow-document.php` that accepts only allowlisted `workflow` + `doc` keys, resolves paths under the repo root, reads files safely, and renders content as escaped preformatted text to avoid unsafe Markdown/HTML rendering. 
- Relocated the `Hero Analysis` navigation item from the `Diagnostics` section into `Hero Tools` in `admin/_nav.php` without changing its href, icon, label, or active-state behavior. 
- Kept changes minimal and consistent with existing admin patterns and avoided adding any unrestricted file-browsing or new data exports.

### Testing
- Ran PHP syntax checks with `php -l` for `admin/review-approvals.php`, `admin/review-workflow-document.php`, and `admin/_nav.php`, all returning no syntax errors. 
- Verified the primary worksheet action and workflow document links appear on the Review Approvals page by including the page and searching for the link text. 
- Validated the document viewer serves allowlisted documents and rejects arbitrary/unlisted paths by including `admin/review-workflow-document.php` with an allowlisted `workflow`+`doc` and with a malicious `doc` and confirming the latter is rejected. 
- Confirmed the sidebar shows `Hero Analysis` under `Hero Tools` and that its active state works for `/admin/debug/hero-analysis.php`; all checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a17f5b31bac8324babc0a984b966b89)