### PR TITLE
Add Ryderwear Batch 2 review-decision gate report

### DIFF
--- a/docs/operations/generated/batches/ryderwear-batch2-2026-05-27-01/review_decision_gate_report.md
+++ b/docs/operations/generated/batches/ryderwear-batch2-2026-05-27-01/review_decision_gate_report.md
@@ -1,0 +1,159 @@
+# Ryderwear Batch 2 review decision gate report
+
+## 1. Executive summary
+- This report analyzes the saved human reviewer acceptance record at `human_reviewer_acceptance_record.json` for Ryderwear Batch 2.
+- The saved record is draft or in-progress because `saved_as` is `draft`, and there is no JSON field indicating final approval state.
+- This report is documentation-only and does not execute copy, import, reconciliation, or publish actions.
+- Downstream artifacts remain blocked overall. A narrow subset of cases is conditionally eligible for later documentation-level source evidence preparation only, and not eligible for copy simulation or import.
+
+## 2. Record metadata
+Extracted from `human_reviewer_acceptance_record.json`:
+
+| field | value |
+|---|---|
+| workflow_id | ryderwear-batch-2 |
+| workflow_title | Ryderwear Batch 2 |
+| submitted_at | 2026-05-28T12:50:05+00:00 |
+| saved_as | draft |
+| last_save_scope | full_form |
+| last_saved_anchor | save-bottom |
+| record_type | human_reviewer_acceptance_record |
+| downstream_artifacts_blocked | true |
+
+## 3. Decision counts
+Status counts by section.
+
+### split_destination_decisions (11 total)
+- accept_proposed: 0
+- revise_proposed: 0
+- reject_proposed: 0
+- defer_decision: 11
+- empty or missing: 0
+
+### item_184_decision (1 total)
+- accept_proposed: 0
+- revise_proposed: 0
+- reject_proposed: 0
+- defer_decision: 1
+- empty or missing: 0
+
+### suspicious_remap_decisions (3 total)
+- accept_proposed: 2
+- revise_proposed: 0
+- reject_proposed: 0
+- defer_decision: 1
+- empty or missing: 0
+
+### batch_policy_decisions (4 total)
+- accept_proposed: 0
+- revise_proposed: 0
+- reject_proposed: 0
+- defer_decision: 4
+- empty or missing: 0
+
+### Overall total (19 decisions)
+- accept_proposed: 2
+- revise_proposed: 0
+- reject_proposed: 0
+- defer_decision: 17
+- empty or missing: 0
+
+## 4. Accepted decisions
+Only decisions with `human_acceptance_status = accept_proposed` are listed.
+
+1) Key: suspicious-02  
+- itemId: not provided in saved reviewer JSON (slug only)  
+- human_final_decision: approve based on visible product/image evidence  
+- human_reviewer_notes: Product/image evidence is visible in the Review Approvals form and supports the proposed decision.  
+- relevant source context: appears in suspicious/remap scope in `proposed_reviewer_decisions.md`, `approval_decision_readiness_review.md`, `image_field_update_plan.csv`, and `publication_gate_report.csv`.  
+- visible product/image evidence basis: yes, explicitly stated in reviewer notes.
+
+2) Key: suspicious-03  
+- itemId: not provided in saved reviewer JSON (slug only)  
+- human_final_decision: approve based on visible product/image evidence  
+- human_reviewer_notes: Product/image evidence is visible in the Review Approvals form and supports the proposed decision.  
+- relevant source context: appears in suspicious/remap scope in `proposed_reviewer_decisions.md`, `approval_decision_readiness_review.md`, `image_field_update_plan.csv`, and `publication_gate_report.csv`.  
+- visible product/image evidence basis: yes, explicitly stated in reviewer notes.
+
+## 5. Deferred decisions
+All deferred decisions are grouped by reason from reviewer-entered decisions and notes.
+
+### A) Image evidence not visible
+- split_destination_decisions: dec-001 through dec-011 (all deferred)
+- item_184_decision: itemId 184 (deferred)
+- batch_policy_decisions deferred for:
+  - approved_source_root_policy
+  - deterministic_source_asset_id_policy
+  - checksum_bytes_mime_normalization_policy
+  - provenance_note_policy
+- common reviewer note pattern: image evidence is not visible in the Review Approvals form, so decision was deferred.
+
+### B) Banner or non-product workflow review required
+- suspicious-01 deferred with final decision: deferred - banner/non-product workflow review required.
+
+### C) Source or provenance evidence required
+- itemId 184 remains deferred with explicit need for provenance evidence before proceeding, consistent with supporting readiness artifacts.
+
+### D) Policy or source-root decision still missing
+- approved_source_root_policy is deferred.
+- deterministic source asset id and normalization policies are also deferred in the saved record, so policy baseline is incomplete.
+
+### E) Other or manual review required
+- suspicious-01 additionally requires separate manual pathway treatment as non-product/banner workflow.
+
+## 6. Banner/non-product handling
+- The saved reviewer record explicitly classifies suspicious-01 as a banner and non-product item.
+- This must not be treated as product-item visual approval.
+- Recommended handling is a separate banner or non-product review pathway with explicit workflow criteria and approval logging outside product-item visual acceptance.
+
+## 7. itemId 184 deferred provenance case
+- itemId 184 is recorded as `defer_decision`.
+- human_final_decision is deferred due to image evidence not visible in the Review Approvals form.
+- Evidence still required before progression:
+  1. reviewer-confirmed source provenance evidence for ownership,
+  2. approved source-root decision alignment,
+  3. explicit reviewer decision update after evidence is visible and verified.
+
+## 8. Suspicious or remap cases
+1) suspicious-01 (`ryderwear_female_nkd_leggings_v_full_length_scrunch`)
+- status: defer_decision
+- reviewer outcome: deferred - banner/non-product workflow review required
+- visible image evidence according to reviewer record: no product-item approval; treated as banner/non-product.
+
+2) suspicious-02 (`ryderwear_unisex_gym_bag_accessories`)
+- status: accept_proposed
+- reviewer outcome: approve based on visible product/image evidence
+- visible image evidence according to reviewer record: yes.
+
+3) suspicious-03 (`ryderwear_female_nkd_shorts_v_scrunch`)
+- status: accept_proposed
+- reviewer outcome: approve based on visible product/image evidence
+- visible image evidence according to reviewer record: yes.
+
+No additional approval is inferred beyond these recorded reviewer outcomes.
+
+## 9. Batch-level policy decisions
+Policy outcomes from saved record:
+- source-root policy (`approved_source_root_policy`): deferred.
+- source_asset_id policy (`deterministic_source_asset_id_policy`): deferred.
+- checksum or bytes or MIME normalization (`checksum_bytes_mime_normalization_policy`): deferred.
+- provenance-note policy (`provenance_note_policy`): deferred.
+
+Implication:
+- Source-root and normalization policy decisions remain unresolved.
+- Controlled source evidence inventory and copy simulation remain blocked, except that documentation-only preparation planning may be conditionally eligible for accepted case subsets.
+
+## 10. Gate conclusion
+Gate status: **partially approved / source evidence preparation only**.
+
+Rationale:
+- There are 2 accepted suspicious/remap decisions.
+- 17 decisions remain deferred, including all split-destination decisions, itemId 184, and all batch policy decisions.
+- `downstream_artifacts_blocked` is explicitly true in the saved record.
+- Therefore this batch is not ready for copy simulation, import, or reconciliation.
+
+## 11. Recommended next step
+Next safest Codex task:
+- Complete missing policy and source-root decisions first, using a controlled source-root approval worksheet.
+- In parallel, produce a report-only accepted vs deferred decision traceability table.
+- Do not proceed to `source_asset_inventory.csv`, `suspicious_mapping_report.csv`, or `copy_simulation.csv` generation until policy and deferred decision blockers are explicitly resolved in reviewer-approved records.


### PR DESCRIPTION
### Motivation
- Provide a documentation-only gate analysis of the saved human reviewer acceptance record for Ryderwear Batch 2 to clarify what is approved, what is deferred, and the next safe workflow step.
- Preserve conservative gating so downstream artifacts remain blocked unless the reviewer record explicitly unblocks them.

### Description
- Added `docs/operations/generated/batches/ryderwear-batch2-2026-05-27-01/review_decision_gate_report.md` which analyzes `human_reviewer_acceptance_record.json` and related artifacts and includes the required sections (executive summary, record metadata, decision counts, accepted/deferred listings, banner handling, itemId 184 coverage, suspicious/remap summary, policy decisions, gate conclusion, and recommended next step).
- Extracted and reported metadata fields: `workflow_id`, `workflow_title`, `submitted_at`, `saved_as`, `last_save_scope`, `last_saved_anchor`, `record_type`, and `downstream_artifacts_blocked`.
- Counted decisions by `human_acceptance_status` across `split_destination_decisions`, `item_184_decision`, `suspicious_remap_decisions`, and `batch_policy_decisions`, and enumerated accepted vs deferred cases with reviewer notes and evidence basis.
- Concluded a conservative gate status of "partially approved / source evidence preparation only" and recommended completing policy and source-root decisions before any `source_asset_inventory.csv`, `suspicious_mapping_report.csv`, or `copy_simulation.csv` work.

### Testing
- Parsed the saved reviewer JSON with `python -m json.tool` (result: OK).
- Verified report references required terms and artifact filenames with text searches for `human_reviewer_acceptance_record.json`, `source_asset_inventory.csv`, `suspicious_mapping_report.csv`, `copy_simulation.csv`, `accept_proposed`, and `defer_decision` (results: OK).
- Ran a non-ASCII check on the new Markdown file (result: ASCII-only).
- Confirmed repository change set contained only the new report before committing and added the file (result: commit created and file added).
- Created PR metadata with a concise title and summary describing the added documentation-only gate report.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a183ed1c3b083249db2b2e7d18e603c)