### PR TITLE
Prepare Ryderwear policy worksheet for manual completion

### DIFF
--- a/docs/operations/generated/batches/ryderwear-batch2-2026-05-27-01/source_root_and_policy_completion_worksheet.md
+++ b/docs/operations/generated/batches/ryderwear-batch2-2026-05-27-01/source_root_and_policy_completion_worksheet.md
@@ -1,5 +1,38 @@
 # Ryderwear Batch 2 source-root and policy completion worksheet
 
+## Manual completion guidance
+
+This worksheet should be completed manually in Markdown first. Markdown completion is preferred before an admin UI because the policy structure is still being stabilized. A fillable admin UI may be built later after one completed Markdown example exists.
+
+Completing this worksheet does not itself authorize copying, import, publication, storefront changes, ProductDB updates, or downstream artifact generation.
+
+## Completion status
+
+| Field | Value |
+|---|---|
+| worksheet_completion_status | incomplete |
+| completed_by | TBD |
+| completion_date | TBD |
+| review_scope | TBD |
+| final_gate_recommendation | TBD |
+| next_allowed_task | TBD |
+| downstream_artifacts_unblocked | no |
+
+## What completion means
+
+Completing this worksheet may authorize only the next controlled task: generating a Ryderwear Batch 2 candidate product-image-set manifest from approved source roots and accepted/eligible decisions.
+
+Completing this worksheet does not authorize:
+
+- `source_asset_inventory.csv` as canonical source truth
+- `suspicious_mapping_report.csv`
+- `copy_simulation.csv`
+- image copying
+- SQL/import payloads
+- ProductDB changes
+- storefront gallery changes
+- publication
+
 ## 1. Purpose
 
 This worksheet is documentation-only. It records the remaining human, source-root, and policy decisions required before controlled source-evidence preparation can proceed for Ryderwear Batch 2.
@@ -407,6 +440,10 @@ Conservative gate recommendation:
 - SQL/import payloads remain blocked until later gates.
 - Storefront publication and storefront gallery exports remain blocked until later gates.
 - This worksheet does not unblock copy simulation, image copying, import, reconciliation, publication, ProductDB changes, admin views, storefront views, or public storefront changes.
+
+## Future admin UI note
+
+After this worksheet is completed once in Markdown, a future admin UI can be designed around the stable decision fields. The UI should not be built first because the policy structure is still being settled.
 
 ## 14. Recommended next Codex task
 


### PR DESCRIPTION
### Motivation
- Make the Ryderwear Batch 2 worksheet easier for humans to complete by adding explicit manual guidance and a compact status block near the top. 
- Clarify the narrow scope of what a completed worksheet may authorize and restate that many downstream artifact tasks remain blocked. 
- Document that an admin UI should wait until a completed Markdown example stabilizes policy fields. 

### Description
- Inserted a `Manual completion guidance` section near the top of `docs/operations/generated/batches/ryderwear-batch2-2026-05-27-01/source_root_and_policy_completion_worksheet.md` explaining why Markdown completion is preferred and that completion does not authorize downstream actions. 
- Added a `Completion status` table with the required fields including `worksheet_completion_status: incomplete`, `completed_by: TBD`, `completion_date: TBD`, `review_scope: TBD`, `final_gate_recommendation: TBD`, `next_allowed_task: TBD`, and `downstream_artifacts_unblocked: no`. 
- Added a `What completion means` note limiting any authorization to only generating a Ryderwear Batch 2 candidate product-image-set manifest and enumerating artefacts that remain unauthorized (for example `source_asset_inventory.csv`, `suspicious_mapping_report.csv`, `copy_simulation.csv`, image copying, SQL/import payloads, ProductDB changes, storefront changes, and publication). 
- Appended a `Future admin UI note` near the end advising that a UI should be designed only after a completed Markdown example exists and the decision fields stabilize, and kept the change limited to the single worksheet file without filling any human decision fields. 

### Testing
- Verified the modified file is ASCII-only and contains the required phrases and fields including `Manual completion guidance`, `worksheet_completion_status`, `admin UI`, `downstream_artifacts_unblocked`, `candidate product-image-set manifest`, `source_asset_inventory.csv`, `suspicious_mapping_report.csv`, and `copy_simulation.csv`. 
- Confirmed the repository shows only the intended worksheet file as the modification prior to finalizing the update. 
- Recorded the change in repository history and created PR metadata for review.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a18f2cb39e08324be8244607b617614)