### PR TITLE
Complete Ryderwear source-root decision

### DIFF
--- a/docs/operations/generated/batches/ryderwear-batch2-2026-05-27-01/source_root_and_policy_completion_worksheet.md
+++ b/docs/operations/generated/batches/ryderwear-batch2-2026-05-27-01/source_root_and_policy_completion_worksheet.md
@@ -92,14 +92,14 @@ Human reviewer or policy owner completion area:
 
 | Field | Human completion value |
 |---|---|
-| approved_source_root | TBD |
-| approved_source_root_type | TBD |
-| source_root_owner_or_origin | TBD |
-| source_root_scope | TBD |
-| source_root_exclusions | TBD |
-| reviewer_decision | TBD |
-| reviewer_notes | TBD |
-| approval_date | TBD |
+| approved_source_root | images/brands/ryderwear |
+| approved_source_root_type | repository_path |
+| source_root_owner_or_origin | Sports Warehouse repository-local Ryderwear image corpus, previously curated/imported for this project |
+| source_root_scope | Ryderwear product/image evidence paths under images/brands/ryderwear only, limited to accepted/eligible Ryderwear Batch 2 decisions |
+| source_root_exclusions | exclude unrelated brands, broad user folders, generated reports, SQL files, public storefront publication outputs, deferred item sets, unresolved itemId 184, and banner/non_product cases unless separately approved |
+| reviewer_decision | approve_source_root |
+| reviewer_notes | Approved only as a controlled source/evidence corpus for generating a Ryderwear Batch 2 candidate product-image-set manifest. This does not approve image copying, ProductDB updates, SQL/import payloads, copy simulation, storefront gallery changes, or publication. |
+| approval_date | 2026-05-29 |
 
 Required source-root constraints:
 


### PR DESCRIPTION
### Motivation
- Record an explicit, narrow repository-local source-root approval to enable future controlled generation of a Ryderwear Batch 2 candidate product-image-set manifest. 
- Populate only Section 4 of the existing worksheet so the rest of the policy review remains in draft/TBD state.

### Description
- Updated the Section 4 human reviewer table fields with the approved values including `approved_source_root: images/brands/ryderwear` and `approved_source_root_type: repository_path`. 
- Added `source_root_owner_or_origin`, `source_root_scope`, `source_root_exclusions`, `reviewer_decision: approve_source_root`, `reviewer_notes` with the narrow approval caveats, and `approval_date: 2026-05-29`. 
- Preserved all other worksheet content, left all other policy fields as `TBD`, did not change the completion status block, and did not mark the worksheet complete. 

### Testing
- Verified the file is ASCII-only and the check passed. 
- Confirmed Section 4 contains the strings `images/brands/ryderwear`, `repository_path`, `approve_source_root`, `2026-05-29`, `candidate product-image-set manifest`, and the phrase `This does not approve image copying`. 
- Confirmed `TBD` values remain outside Section 4 and the `worksheet_completion_status` remains `incomplete`. 
- Confirmed only the intended worksheet file was modified and all validation checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a18f82cb8ac8324841634400a5051ef)