### PR TITLE
Add Ryderwear copy simulation review gate

### DIFF
--- a/docs/operations/generated/batches/ryderwear-batch2-2026-05-27-01/copy_simulation_review_gate_report.md
+++ b/docs/operations/generated/batches/ryderwear-batch2-2026-05-27-01/copy_simulation_review_gate_report.md
@@ -1,0 +1,120 @@
+# Ryderwear Batch 2 copy-simulation review gate report
+
+## 1. Executive summary
+
+- copy_simulation.csv has been reviewed.
+- The copy simulation was derived from the v2 canonical manifest only.
+- The simulation contains 14 rows.
+- All rows are no_copy_needed.
+- All rows are same_path.
+- All rows are ready_no_copy_required.
+- No image-copy task is needed for the 14 approved v2 manifest rows.
+- No files were copied.
+- Downstream artifacts remain blocked.
+- ProductDB updates remain blocked.
+- SQL/import execution remains blocked.
+- Storefront gallery changes remain blocked.
+- Publication remains blocked.
+
+## 2. Inputs reviewed
+
+- v2 JSON manifest: `docs/operations/generated/batches/ryderwear-batch2-2026-05-27-01/ryderwear_batch2_2026_05_27_candidate_product_image_set_manifest_v2.json`
+- v2 manifest report: `docs/operations/generated/batches/ryderwear-batch2-2026-05-27-01/ryderwear_batch2_2026_05_27_candidate_product_image_set_manifest_v2_report.md`
+- v2 flat CSV mirror: `docs/operations/generated/batches/ryderwear-batch2-2026-05-27-01/ryderwear_batch2_2026_05_27_candidate_product_image_set_manifest_v2_flat.csv`
+- v2 manifest gate report: `docs/operations/generated/batches/ryderwear-batch2-2026-05-27-01/ryderwear_batch2_2026_05_27_manifest_v2_gate_report.md`
+- copy-simulation readiness gate report: `docs/operations/generated/batches/ryderwear-batch2-2026-05-27-01/ryderwear_batch2_2026_05_27_copy_simulation_readiness_gate_report.md`
+- copy_simulation.csv: `docs/operations/generated/batches/ryderwear-batch2-2026-05-27-01/copy_simulation.csv`
+- copy_simulation_report.md: `docs/operations/generated/batches/ryderwear-batch2-2026-05-27-01/copy_simulation_report.md`
+- architecture/schema documents:
+  - `docs/architecture/product-image-set-manifest-architecture.md`
+  - `docs/architecture/product-image-set-manifest-schema.md`
+
+## 3. Copy simulation validation
+
+| Check | Result | Evidence |
+|---|---|---|
+| CSV exists | passed | `copy_simulation.csv` is present in the batch directory. |
+| CSV has exactly 14 data rows | passed | The CSV contains 14 data rows, one row for each approved v2 ImageAsset. |
+| rows are derived from v2 manifest only | passed | `manifest_id` is `ryderwear_batch2_2026_05_27_candidate_product_image_set_manifest_v2` on every row. |
+| item_id values are only 68 and 96 | passed | item_id 68 has 8 rows; item_id 96 has 6 rows. |
+| model_id values are only approved v2 model IDs | passed | The only values are `ryderwear_unisex_gym_bag_accessories` and `ryderwear_female_nkd_shorts_v_scrunch`. |
+| product_key is absent | passed | `product_key` is not a column in `copy_simulation.csv` and is absent from the v2 manifest identity model. |
+| external_item_id is absent | passed | `external_item_id` is not a column in `copy_simulation.csv` and is absent from the v2 manifest identity model. |
+| suspicious-01 is absent | passed | No row contains `suspicious-01`. |
+| itemId 184 is absent | passed | No row contains itemId 184, and no `item_id` value equals 184. |
+| dec-001 through dec-011 are absent | passed | No row contains `dec-001`, `dec-002`, `dec-003`, `dec-004`, `dec-005`, `dec-006`, `dec-007`, `dec-008`, `dec-009`, `dec-010`, or `dec-011`. |
+| all source_root_scope values are images/brands/ryderwear | passed | Every row has `source_root_scope` equal to `images/brands/ryderwear`. |
+| every resolved_source_path equals images/brands/ryderwear/{source_relpath} | passed | Each `resolved_source_path` preserves `source_relpath` under `images/brands/ryderwear`. |
+| every proposed_destination_path equals images/brands/ryderwear/{source_relpath} | passed | Each `proposed_destination_path` preserves `source_relpath` under `images/brands/ryderwear`. |
+| every proposed_destination_relpath equals source_relpath | passed | `proposed_destination_relpath` matches `source_relpath` on every row. |
+| every proposed_destination_filename equals original_filename | passed | `proposed_destination_filename` matches `original_filename` on every row. |
+| every copy_action is no_copy_needed | passed | `copy_action` is `no_copy_needed` on all 14 rows. |
+| every collision_status is same_path | passed | `collision_status` is `same_path` on all 14 rows. |
+| every readiness_status is ready_no_copy_required | passed | `readiness_status` is `ready_no_copy_required` on all 14 rows. |
+| no blocked rows exist | passed | blocked rows: 0. |
+| no image copy occurred | passed | The simulation report states no files were copied, and this gate did not copy images. |
+| no SQL/import payload was generated | passed | SQL/import payload generation remains blocked. |
+| no ProductDB update occurred | passed | ProductDB updates remain blocked. |
+| no storefront update occurred | passed | Storefront gallery changes remain blocked. |
+| no publication occurred | passed | Publication remains blocked. |
+
+## 4. Simulation result summary
+
+### copy_action
+
+- copy_action no_copy_needed: 14
+
+### collision_status
+
+- collision_status same_path: 14
+
+### readiness_status
+
+- readiness_status ready_no_copy_required: 14
+
+### proposed_destination_exists
+
+- proposed_destination_exists true: 14
+
+### block_reason
+
+- block_reason empty: 14
+- blocked rows: 0
+
+## 5. Interpretation
+
+The approved images are already located in the canonical repository path under `images/brands/ryderwear`. The destination policy is `preserve_manifest_source_relpath_under_approved_root`, so the proposed destination path is `images/brands/ryderwear/{source_relpath}` for every row.
+
+Because every source path already matches the proposed destination path, every row is `no_copy_needed`, `same_path`, and `ready_no_copy_required`. Therefore a controlled image-copy step is unnecessary for these 14 approved v2 manifest rows.
+
+This does not approve ProductDB, SQL/import, admin/runtime, storefront gallery, or publication work. It only means the file-copy portion can be skipped for this approved v2 subset.
+
+## 6. Excluded cases
+
+The following cases remain excluded from this review gate and from the approved copy-simulation subset:
+
+- `suspicious-01` / `ryderwear_female_nkd_leggings_v_full_length_scrunch`
+- itemId 184
+- `dec-001` through `dec-011`
+- all deferred cases
+- all banner/non_product cases
+- products outside item_id 68 and item_id 96
+
+## 7. Gate conclusion
+
+copy_simulation_review_gate_passed_no_copy_needed
+
+This conclusion means:
+
+- no image-copy task is needed for the 14 approved v2 manifest rows
+- import/update planning may be considered next as a planning-only task
+- actual ProductDB updates remain blocked
+- SQL/import execution remains blocked
+- storefront gallery changes remain blocked
+- publication remains blocked
+
+## 8. Next allowed task recommendation
+
+Prepare Ryderwear Batch 2 import/update planning from manifest v2 and copy simulation results.
+
+The next task must be planning-only. It must not execute SQL, update ProductDB, alter runtime code, update storefront galleries, publish anything, or otherwise unblock ProductDB updates, SQL execution, storefront changes, or publication.


### PR DESCRIPTION
### Motivation

- Record a documentation-only review gate that confirms the Ryderwear Batch 2 copy simulation derived from the v2 canonical manifest requires no image-copy work for the approved rows.
- Make an explicit, auditable decision about the next safe workflow boundary so planning may proceed while downstream actions remain blocked.

### Description

- Add a new review gate report at `docs/operations/generated/batches/ryderwear-batch2-2026-05-27-01/copy_simulation_review_gate_report.md` that documents inputs reviewed, a validation checklist, the simulation summary counts, exclusions, interpretation, gate conclusion `copy_simulation_review_gate_passed_no_copy_needed`, and the next-task recommendation.
- The report asserts the simulation was derived from the v2 canonical manifest only, contains 14 rows (item_id 68 and 96), all rows are `no_copy_needed` / `same_path` / `ready_no_copy_required`, and no files were copied.
- The report reaffirms that ProductDB updates, SQL/import execution, storefront gallery changes, and publication remain blocked and that the next allowed task is planning-only import/update preparation. 
- No other repository files, manifest JSON, CSVs, images, ProductDB, SQL payloads, or runtime/front-end code were modified by this change.

### Testing

- Confirmed the new report file is ASCII-only and contains required gate phrases and conclusion `copy_simulation_review_gate_passed_no_copy_needed`.
- Ran automated validation that read `copy_simulation.csv` and the v2 flat mirror to assert 14 data rows, `manifest_id` derived from v2 only, `item_id` values `{68,96}`, `model_id` values limited to the two approved model ids, absence of `product_key` and `external_item_id`, absence of excluded identifiers (e.g. `suspicious-01`, `184`, `dec-001`..`dec-011`), path equivalence checks for `resolved_source_path` and `proposed_destination_path`, and that every row reports `copy_action=no_copy_needed`, `collision_status=same_path`, `readiness_status=ready_no_copy_required`, and empty `block_reason`.
- Verified repository status to confirm only the new report file was added before finalizing the change and that all automated checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a19600930ec83249366c370aedfacd9)